### PR TITLE
Skip dotnet setup if pytket-qsharp not among modules to test.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -118,6 +118,7 @@ jobs:
         echo "MODULES_TO_TEST=${MM}" >> $GITHUB_ENV
 
     - name: Install dotnet SDK and iqsharp
+      if: contains(env.MODULES_TO_TEST, 'pytket-qsharp')
       run: |
         brew install mono-libgdiplus jupyter
         wget https://dot.net/v1/dotnet-install.sh


### PR DESCRIPTION
Already doing this on other platforms, but not on MacOS for some reason.