### PR TITLE
Add workflow to create Jira task when new issue created.

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,0 +1,23 @@
+name: New issue
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  jira_task:
+    name: Create Jira task
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Login
+      uses: atlassian/gajira-login@v2.0.0
+      env:
+        JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+        JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+        JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+    - name: Create
+      uses: atlassian/gajira-create@v2.0.1
+      with:
+        project: TKET
+        issuetype: Task
+        summary: Close ${{ github.context.issue.number }} on ${{ github.repository }}


### PR DESCRIPTION
According to https://docs.github.com/en/actions/reference/events-that-trigger-workflows#issues this will only be triggered if the workflow file is on the default branch, so I can't think of a good way to test it before merging.
(The necessary secrets have been added to the repo.)