### PR TITLE
[pytket-braket] Fix tests.

### DIFF
--- a/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
+++ b/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
@@ -775,4 +775,5 @@ class BraketBackend(Backend):
             raise NotImplementedError("Circuits on local device cannot be cancelled")
         task_id = handle[0]
         task = AwsQuantumTask(task_id)
-        task.cancel()
+        if task.state() != "COMPLETED":
+            task.cancel()

--- a/modules/pytket-braket/tests/backend_test.py
+++ b/modules/pytket-braket/tests/backend_test.py
@@ -132,7 +132,7 @@ def test_rigetti() -> None:
         s3_folder=S3_FOLDER,
         device_type="qpu",
         provider="rigetti",
-        device="Aspen-8",
+        device="Aspen-9",
     )
     assert b.persistent_handles
     assert b.supports_shots
@@ -173,7 +173,7 @@ def test_rigetti_with_rerouting() -> None:
         s3_folder=S3_FOLDER,
         device_type="qpu",
         provider="rigetti",
-        device="Aspen-8",
+        device="Aspen-9",
     )
     c = Circuit(4).CX(0, 1).CX(0, 2).CX(0, 3).CX(1, 2).CX(1, 3).CX(2, 3)
     b.compile_circuit(c)

--- a/modules/pytket-braket/tests/pytest.ini
+++ b/modules/pytket-braket/tests/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+filterwarnings =
+    ignore:Call to deprecated create function FieldDescriptor
+    ignore:Call to deprecated create function Descriptor
+    ignore:Call to deprecated create function EnumDescriptor
+    ignore:Call to deprecated create function EnumValueDescriptor
+    ignore:Call to deprecated create function FileDescriptor
+    ignore:Call to deprecated create function OneofDescriptor


### PR DESCRIPTION
* Switch to Aspen-9 for remote tests.
* Don't call `cancel` on completed tasks.
* Ignore some deprecation warnings.