### PR TITLE
Remove "type: ignore" annotation when importing numpy.

### DIFF
--- a/modules/pytket-aqt/tests/backend_test.py
+++ b/modules/pytket-aqt/tests/backend_test.py
@@ -16,7 +16,7 @@ from collections import Counter
 from typing import cast
 import os
 from hypothesis import given, strategies
-import numpy as np  # type: ignore
+import numpy as np
 import pytest
 from pytket.circuit import Circuit  # type: ignore
 from pytket.backends import StatusEnum

--- a/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
+++ b/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
@@ -69,7 +69,7 @@ from braket.circuits.result_type import ResultType  # type: ignore
 from braket.device_schema import DeviceActionType  # type: ignore
 from braket.devices import LocalSimulator  # type: ignore
 from braket.tasks.local_quantum_task import LocalQuantumTask  # type: ignore
-import numpy as np  # type: ignore
+import numpy as np
 
 # Known schemas for noise characteristics
 IONQ_SCHEMA = {

--- a/modules/pytket-braket/pytket/extensions/braket/braket_convert.py
+++ b/modules/pytket-braket/pytket/extensions/braket/braket_convert.py
@@ -18,7 +18,7 @@
 from typing import Iterable, Optional
 from pytket.circuit import Circuit, OpType  # type: ignore
 from braket.circuits import Circuit as BK_Circuit  # type: ignore
-from numpy import pi  # type: ignore
+from numpy import pi
 
 
 def tk_to_braket(tkcirc: Circuit, allqbs: Optional[Iterable[int]] = None) -> BK_Circuit:

--- a/modules/pytket-braket/tests/backend_test.py
+++ b/modules/pytket-braket/tests/backend_test.py
@@ -16,7 +16,7 @@ from collections import Counter
 from typing import cast
 import os
 from hypothesis import given, strategies
-import numpy as np  # type: ignore
+import numpy as np
 import pytest
 from pytket.extensions.braket import BraketBackend
 from pytket.circuit import Circuit, OpType, Qubit  # type: ignore

--- a/modules/pytket-cirq/tests/test_cirq_backend.py
+++ b/modules/pytket-cirq/tests/test_cirq_backend.py
@@ -16,7 +16,7 @@ from collections import Counter
 from typing import List
 import math
 from hypothesis import given, strategies
-import numpy as np  # type: ignore
+import numpy as np
 from pytket.extensions.cirq import (
     CirqDensityMatrixSampleBackend,
     CirqDensityMatrixSimBackend,

--- a/modules/pytket-honeywell/pytket/extensions/honeywell/backends/honeywell.py
+++ b/modules/pytket-honeywell/pytket/extensions/honeywell/backends/honeywell.py
@@ -18,7 +18,7 @@ import json
 from http import HTTPStatus
 from typing import Dict, Iterable, List, Optional, Sequence, Any, cast
 
-import numpy as np  # type: ignore
+import numpy as np
 import requests
 import keyring  # type: ignore
 

--- a/modules/pytket-honeywell/tests/backend_test.py
+++ b/modules/pytket-honeywell/tests/backend_test.py
@@ -16,7 +16,7 @@ from typing import Callable, Any  # pylint: disable=unused-import
 from ast import literal_eval
 import os
 from hypothesis import given, settings, strategies
-import numpy as np  # type: ignore
+import numpy as np
 import pytest
 import hypothesis.strategies as st
 from hypothesis.strategies._internal import SearchStrategy

--- a/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq_convert.py
+++ b/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq_convert.py
@@ -15,7 +15,7 @@
 from typing import Dict, Tuple, Any, List
 from pytket.passes import RebaseCustom  # type: ignore
 from pytket.circuit import Circuit, OpType, Command  # type: ignore
-from numpy import pi  # type: ignore
+from numpy import pi
 
 
 def _from_tk1(a: float, b: float, c: float) -> Circuit:

--- a/modules/pytket-ionq/tests/backend_test.py
+++ b/modules/pytket-ionq/tests/backend_test.py
@@ -16,7 +16,7 @@ from collections import Counter
 from typing import cast
 import os
 from hypothesis import given, strategies
-import numpy as np  # type: ignore
+import numpy as np
 import pytest
 from pytket.circuit import Circuit  # type: ignore
 from pytket.backends.backend_exceptions import CircuitNotValidError

--- a/modules/pytket-projectq/pytket/extensions/projectq/backends/projectq_backend.py
+++ b/modules/pytket-projectq/pytket/extensions/projectq/backends/projectq_backend.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Iterable, List, Optional
 from uuid import uuid4
 from logging import warning
 
-import numpy as np  # type: ignore
+import numpy as np
 import projectq  # type: ignore
 from projectq import MainEngine
 from projectq.backends import Simulator  # type: ignore

--- a/modules/pytket-projectq/pytket/extensions/projectq/projectq_convert.py
+++ b/modules/pytket-projectq/pytket/extensions/projectq/projectq_convert.py
@@ -24,7 +24,7 @@ from projectq.ops._command import Command as ProjectQCommand, apply_command  # t
 from projectq.types._qubit import Qureg  # type: ignore
 from pytket.circuit import OpType, Op, Circuit, Command, Bit  # type: ignore
 from pytket.transform import Transform  # type: ignore
-import numpy as np  # type: ignore
+import numpy as np
 
 _pq_to_tk_singleqs = {
     pqo.XGate: OpType.X,

--- a/modules/pytket-projectq/tests/projectq_backend_test.py
+++ b/modules/pytket-projectq/tests/projectq_backend_test.py
@@ -20,7 +20,7 @@ import warnings
 from collections import Counter
 
 from hypothesis import given, strategies
-import numpy as np  # type: ignore
+import numpy as np
 import pytest
 from pytket.backends.backend_exceptions import CircuitNotRunError
 from pytket.backends.status import StatusEnum

--- a/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
+++ b/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
@@ -17,7 +17,7 @@ from typing import Iterable, List, Optional
 from uuid import uuid4
 from logging import warning
 
-import numpy as np  # type: ignore
+import numpy as np
 from pyquil import get_qc
 from pyquil.api import QuantumComputer, WavefunctionSimulator
 from pyquil.gates import I

--- a/modules/pytket-pyquil/tests/pyquil_convert_test.py
+++ b/modules/pytket-pyquil/tests/pyquil_convert_test.py
@@ -17,7 +17,7 @@ from shutil import which
 import platform
 
 import docker  # type: ignore
-import numpy as np  # type: ignore
+import numpy as np
 import pytest
 from pyquil import Program
 from pyquil.api import WavefunctionSimulator

--- a/modules/pytket-pyquil/tests/qvm_backend_test.py
+++ b/modules/pytket-pyquil/tests/qvm_backend_test.py
@@ -19,7 +19,7 @@ import platform
 
 from typing import cast
 import docker  # type: ignore
-import numpy as np  # type: ignore
+import numpy as np
 import pytest
 from _pytest.fixtures import FixtureRequest
 

--- a/modules/pytket-pyzx/tests/pyzx_convert_test.py
+++ b/modules/pytket-pyzx/tests/pyzx_convert_test.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     from pytket.extensions.backends.qiskit import AerStateBackend  # type: ignore
 
-import numpy as np  # type: ignore
+import numpy as np
 import pytest
 
 

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
@@ -17,7 +17,7 @@ from collections import defaultdict
 from logging import warning
 from typing import Dict, Iterable, List, Optional, Tuple, cast, TYPE_CHECKING, Set
 
-import numpy as np  # type: ignore
+import numpy as np
 import qiskit.providers.aer.extensions.snapshot_expectation_value  # type: ignore # pylint: disable=unused-import
 from pytket.backends import Backend, CircuitNotRunError, CircuitStatus, ResultHandle
 from pytket.backends.backendresult import BackendResult

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/result_convert.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/result_convert.py
@@ -11,7 +11,7 @@ from typing import (
 )
 from collections import Counter
 
-import numpy as np  # type: ignore
+import numpy as np
 
 from qiskit.result import Result  # type: ignore
 from qiskit.result.models import ExperimentResultData  # type: ignore

--- a/modules/pytket-qiskit/tests/backend_test.py
+++ b/modules/pytket-qiskit/tests/backend_test.py
@@ -20,7 +20,7 @@ import math
 import cmath
 import pickle
 from hypothesis import given, strategies
-import numpy as np  # type: ignore
+import numpy as np
 from pytket.circuit import Circuit, OpType, BasisOrder, Qubit, reg_eq  # type: ignore
 from pytket.passes import CliffordSimp  # type: ignore
 from pytket.pauli import Pauli, QubitPauliString  # type: ignore

--- a/modules/pytket-qiskit/tests/qiskit_backend_test.py
+++ b/modules/pytket-qiskit/tests/qiskit_backend_test.py
@@ -14,7 +14,7 @@
 
 from typing import List
 import platform
-import numpy as np  # type: ignore
+import numpy as np
 from pytket.backends import Backend
 from pytket.extensions.qiskit import (
     AerBackend,

--- a/modules/pytket-qiskit/tests/qiskit_convert_test.py
+++ b/modules/pytket-qiskit/tests/qiskit_convert_test.py
@@ -16,7 +16,7 @@ from collections import Counter
 from typing import List, Set, Union
 from math import pi
 import pytest
-import numpy as np  # type: ignore
+import numpy as np
 from qiskit import (  # type: ignore
     QuantumCircuit,
     QuantumRegister,

--- a/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
+++ b/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
@@ -18,7 +18,7 @@
 from typing import TYPE_CHECKING, Iterable, List, Optional
 from logging import warning
 from uuid import uuid4
-import numpy as np  # type: ignore
+import numpy as np
 from qulacs import Observable, QuantumState  # type: ignore
 from qulacs.observable import create_observable_from_openfermion_text  # type: ignore
 from pytket.backends import (

--- a/modules/pytket-qulacs/pytket/extensions/qulacs/qulacs_convert.py
+++ b/modules/pytket-qulacs/pytket/extensions/qulacs/qulacs_convert.py
@@ -14,7 +14,7 @@
 
 """Conversion from to tket circuits to Qulacs circuits
 """
-import numpy as np  # type: ignore
+import numpy as np
 from qulacs import QuantumCircuit, gate  # type: ignore
 from pytket.circuit import Circuit, OpType  # type: ignore
 

--- a/modules/pytket-qulacs/tests/test_qulacs_backend.py
+++ b/modules/pytket-qulacs/tests/test_qulacs_backend.py
@@ -16,7 +16,7 @@ from collections import Counter
 import warnings
 import math
 from hypothesis import given, strategies
-import numpy as np  # type: ignore
+import numpy as np
 import pytest
 from openfermion.ops import QubitOperator  # type: ignore
 from openfermion.linalg import eigenspectrum  # type: ignore

--- a/modules/pytket-qulacs/tests/test_qulacs_convert.py
+++ b/modules/pytket-qulacs/tests/test_qulacs_convert.py
@@ -14,7 +14,7 @@
 
 import warnings
 
-import numpy as np  # type: ignore
+import numpy as np
 from qulacs import QuantumCircuit, QuantumState  # type: ignore
 from qulacs.state import inner_product  # type: ignore
 from pytket.circuit import Circuit, OpType  # type: ignore


### PR DESCRIPTION
Requires numpy >= 0.20 to pass mypy checks; this should always be the case on the CI.