### PR TITLE
[pytket-qiskit] match unitary gate labels to gate name

### DIFF
--- a/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
@@ -352,7 +352,7 @@ def append_tk_command_to_qiskit(
     if optype == OpType.Unitary2qBox:
         qargs = [qregmap[q.reg_name][q.index[0]] for q in args]
         u = op.get_matrix()
-        g = UnitaryGate(u, label="u2q")
+        g = UnitaryGate(u, label="unitary")
         return qcirc.append(g, qargs=qargs)
     if optype == OpType.Barrier:
         qargs = [qregmap[q.reg_name][q.index[0]] for q in args]


### PR DESCRIPTION
This allows noise models to be added to unitary gates, as the gate name matches the label. 