### PR TITLE
[pytket-qulacs] Don't warn for no measures. [TKET-1203]

### DIFF
--- a/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
+++ b/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
@@ -141,7 +141,7 @@ class QulacsBackend(Backend):
     ) -> List[ResultHandle]:
         circuit_list = list(circuits)
         if valid_check:
-            self._check_all_circuits(circuit_list, nomeasure_warn=(n_shots is not None))
+            self._check_all_circuits(circuit_list, nomeasure_warn=False)
 
         handle_list = []
         for circuit in circuit_list:

--- a/modules/pytket-qulacs/tests/pytest.ini
+++ b/modules/pytket-qulacs/tests/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+filterwarnings =
+    ignore:Call to deprecated create function FieldDescriptor
+    ignore:Call to deprecated create function Descriptor
+    ignore:Call to deprecated create function EnumDescriptor
+    ignore:Call to deprecated create function EnumValueDescriptor
+    ignore:Call to deprecated create function FileDescriptor
+    ignore:Call to deprecated create function OneofDescriptor


### PR DESCRIPTION
After the next pytket release we can omit the parameter altogether. Meanwhile set it to `False` to avoid warnings.