### PR TITLE
[pytket-cirq] Update Cirq DensityMatrix/State simulators to include all circuit qubits

### DIFF
--- a/modules/pytket-cirq/pytket/extensions/cirq/backends/cirq.py
+++ b/modules/pytket-cirq/pytket/extensions/cirq/backends/cirq.py
@@ -209,8 +209,11 @@ class _CirqSimBackend(_CirqBaseBackend):
         ...
 
     def run_circuit(self, circuit: Circuit, **kwargs: KwargTypes) -> BackendResult:
-        cirq_circ = tk_to_cirq(circuit)
-        _, q_bits = _get_default_uids(cirq_circ, circuit)
+        c = circuit.copy()
+        for q in c.qubits:
+            c.add_gate(OpType.noop, [q])
+        cirq_circ = tk_to_cirq(c)
+        _, q_bits = _get_default_uids(cirq_circ, c)
         return self.package_result(cirq_circ, q_bits)
 
     def process_circuits(
@@ -253,8 +256,11 @@ class _CirqSimBackend(_CirqBaseBackend):
     def run_circuit_moments(
         self, circuit: Circuit, **kwargs: KwargTypes
     ) -> List[BackendResult]:
-        cirq_circ = tk_to_cirq(circuit)
-        _, q_bits = _get_default_uids(cirq_circ, circuit)
+        c = circuit.copy()
+        for q in c.qubits:
+            c.add_gate(OpType.noop, [q])
+        cirq_circ = tk_to_cirq(c)
+        _, q_bits = _get_default_uids(cirq_circ, c)
         return self.package_results(cirq_circ, q_bits)
 
     def process_circuit_moments(
@@ -377,6 +383,7 @@ class CirqDensityMatrixSimBackend(_CirqSimBackend):
         self, circuit: CirqCircuit, q_bits: Sequence[Qubit]
     ) -> List[BackendResult]:
         moments = self._simulator.simulate_moment_steps(circuit)
+        print(circuit, q_bits)
         all_backres = [
             BackendResult(
                 density_matrix=run.density_matrix(copy=True),  # type: ignore

--- a/modules/pytket-cirq/pytket/extensions/cirq/backends/cirq.py
+++ b/modules/pytket-cirq/pytket/extensions/cirq/backends/cirq.py
@@ -228,7 +228,6 @@ class _CirqSimBackend(_CirqBaseBackend):
 
         handle_list = []
         for i, circuit in enumerate(circuit_list):
-            circuit.remove_blank_wires()
             handle = ResultHandle(str(uuid4()), i)
             handle_list.append(handle)
             backres = self.run_circuit(circuit, n_shots=n_shots)
@@ -307,7 +306,6 @@ class _CirqSimBackend(_CirqBaseBackend):
 
         handle_list = []
         for i, circuit in enumerate(circuit_list):
-            circuit.remove_blank_wires()
             handle = ResultHandle(str(uuid4()), i)
             handle_list.append(handle)
             backres = self.run_circuit_moments(circuit)

--- a/modules/pytket-cirq/pytket/extensions/cirq/backends/cirq.py
+++ b/modules/pytket-cirq/pytket/extensions/cirq/backends/cirq.py
@@ -383,7 +383,6 @@ class CirqDensityMatrixSimBackend(_CirqSimBackend):
         self, circuit: CirqCircuit, q_bits: Sequence[Qubit]
     ) -> List[BackendResult]:
         moments = self._simulator.simulate_moment_steps(circuit)
-        print(circuit, q_bits)
         all_backres = [
             BackendResult(
                 density_matrix=run.density_matrix(copy=True),  # type: ignore

--- a/modules/pytket-cirq/pytket/extensions/cirq/backends/cirq.py
+++ b/modules/pytket-cirq/pytket/extensions/cirq/backends/cirq.py
@@ -209,11 +209,8 @@ class _CirqSimBackend(_CirqBaseBackend):
         ...
 
     def run_circuit(self, circuit: Circuit, **kwargs: KwargTypes) -> BackendResult:
-        c = circuit.copy()
-        for q in c.qubits:
-            c.add_gate(OpType.noop, [q])
-        cirq_circ = tk_to_cirq(c)
-        _, q_bits = _get_default_uids(cirq_circ, c)
+        cirq_circ = tk_to_cirq(circuit, copy_all_qubits=True)
+        _, q_bits = _get_default_uids(cirq_circ, circuit)
         return self.package_result(cirq_circ, q_bits)
 
     def process_circuits(
@@ -256,11 +253,8 @@ class _CirqSimBackend(_CirqBaseBackend):
     def run_circuit_moments(
         self, circuit: Circuit, **kwargs: KwargTypes
     ) -> List[BackendResult]:
-        c = circuit.copy()
-        for q in c.qubits:
-            c.add_gate(OpType.noop, [q])
-        cirq_circ = tk_to_cirq(c)
-        _, q_bits = _get_default_uids(cirq_circ, c)
+        cirq_circ = tk_to_cirq(circuit, copy_all_qubits=True)
+        _, q_bits = _get_default_uids(cirq_circ, circuit)
         return self.package_results(cirq_circ, q_bits)
 
     def process_circuit_moments(

--- a/modules/pytket-cirq/pytket/extensions/cirq/cirq_convert.py
+++ b/modules/pytket-cirq/pytket/extensions/cirq/cirq_convert.py
@@ -182,7 +182,7 @@ def cirq_to_tk(circuit: cirq.circuits.Circuit) -> Circuit:
     return tkcirc
 
 
-def tk_to_cirq(tkcirc: Circuit, copy_all_qubits=False) -> cirq.circuits.Circuit:
+def tk_to_cirq(tkcirc: Circuit, copy_all_qubits: bool = False) -> cirq.circuits.Circuit:
     """Converts a tket :py:class:`Circuit` object to a Cirq :py:class:`Circuit`.
 
     :param tkcirc: The input tket :py:class:`Circuit`

--- a/modules/pytket-cirq/pytket/extensions/cirq/cirq_convert.py
+++ b/modules/pytket-cirq/pytket/extensions/cirq/cirq_convert.py
@@ -219,13 +219,9 @@ def tk_to_cirq(tkcirc: Circuit) -> cirq.circuits.Circuit:
                 "Cirq can only support registers of dimension <=2"
             )
     oplst = []
-    unused_qbs = set(tkcirc.qubits)
     for command in tkcirc:
         op = command.op
         optype = op.type
-        for qbit in command.args:
-            if qbit in unused_qbs:
-                unused_qbs.remove(qbit)
         try:
             gatetype = _ops2cirq_mapping[optype]
         except KeyError as error:
@@ -252,10 +248,6 @@ def tk_to_cirq(tkcirc: Circuit) -> cirq.circuits.Circuit:
             else:
                 cirqop = gatetype(exponent=params[0])(*qids)
         oplst.append(cirqop)
-
-    for q in unused_qbs:
-        oplst.append(cirq.ops.I(qmap[q]))
-
     try:
         coeff = cmath.exp(float(tkcirc.phase) * cmath.pi * 1j)
         if coeff != 1.0:

--- a/modules/pytket-cirq/pytket/extensions/cirq/cirq_convert.py
+++ b/modules/pytket-cirq/pytket/extensions/cirq/cirq_convert.py
@@ -190,6 +190,7 @@ def tk_to_cirq(tkcirc: Circuit, copy_all_qubits: bool = False) -> cirq.circuits.
     :return: The Cirq :py:class:`Circuit` corresponding to the input circuit
     """
     if copy_all_qubits:
+        tkcirc = tkcirc.copy()
         for q in tkcirc.qubits:
             tkcirc.add_gate(OpType.noop, [q])
 

--- a/modules/pytket-cirq/pytket/extensions/cirq/cirq_convert.py
+++ b/modules/pytket-cirq/pytket/extensions/cirq/cirq_convert.py
@@ -182,13 +182,17 @@ def cirq_to_tk(circuit: cirq.circuits.Circuit) -> Circuit:
     return tkcirc
 
 
-def tk_to_cirq(tkcirc: Circuit) -> cirq.circuits.Circuit:
+def tk_to_cirq(tkcirc: Circuit, copy_all_qubits=False) -> cirq.circuits.Circuit:
     """Converts a tket :py:class:`Circuit` object to a Cirq :py:class:`Circuit`.
 
     :param tkcirc: The input tket :py:class:`Circuit`
 
     :return: The Cirq :py:class:`Circuit` corresponding to the input circuit
     """
+    if copy_all_qubits:
+        for q in tkcirc.qubits:
+            tkcirc.add_gate(OpType.noop, [q])
+
     qmap = {}
     line_name = None
     grid_name = None

--- a/modules/pytket-cirq/tests/cirq_convert_test.py
+++ b/modules/pytket-cirq/tests/cirq_convert_test.py
@@ -63,9 +63,18 @@ def get_match_circuit() -> cirq.Circuit:
 def test_conversions() -> None:
     circ = get_match_circuit()
     coms = cirq_to_tk(circ)
-    print(str(circ))
-    print(str(tk_to_cirq(coms)))
-    assert str(circ) == str(tk_to_cirq(coms))
+
+    cirq_false = tk_to_cirq(coms, copy_all_qubits=False)
+    cirq_true = tk_to_cirq(coms, copy_all_qubits=True)
+    assert str(circ) == str(cirq_false)
+    assert str(cirq) != str(cirq_true)
+
+    tket_false = cirq_to_tk(cirq_false)
+    tket_true = cirq_to_tk(cirq_true)
+
+    assert len(tket_false.get_commands()) + len(tket_false.qubits) == len(
+        tket_true.get_commands()
+    )
 
 
 def test_device() -> None:

--- a/modules/pytket-cirq/tests/cirq_convert_test.py
+++ b/modules/pytket-cirq/tests/cirq_convert_test.py
@@ -71,10 +71,10 @@ def test_conversions() -> None:
 
     tket_false = cirq_to_tk(cirq_false)
     tket_true = cirq_to_tk(cirq_true)
-
     assert len(tket_false.get_commands()) + len(tket_false.qubits) == len(
         tket_true.get_commands()
     )
+    assert tket_true != coms
 
 
 def test_device() -> None:

--- a/modules/pytket-cirq/tests/cirq_convert_test.py
+++ b/modules/pytket-cirq/tests/cirq_convert_test.py
@@ -67,7 +67,7 @@ def test_conversions() -> None:
     cirq_false = tk_to_cirq(coms, copy_all_qubits=False)
     cirq_true = tk_to_cirq(coms, copy_all_qubits=True)
     assert str(circ) == str(cirq_false)
-    assert str(cirq) != str(cirq_true)
+    assert str(circ) != str(cirq_true)
 
     tket_false = cirq_to_tk(cirq_false)
     tket_true = cirq_to_tk(cirq_true)
@@ -75,6 +75,7 @@ def test_conversions() -> None:
         tket_true.get_commands()
     )
     assert tket_true != coms
+    assert tket_false == coms
 
 
 def test_device() -> None:

--- a/modules/pytket-cirq/tests/test_cirq_backend.py
+++ b/modules/pytket-cirq/tests/test_cirq_backend.py
@@ -116,13 +116,14 @@ def test_moment_backends() -> None:
 
 
 def test_state() -> None:
-    c = Circuit(2).H(0).CX(0, 1)
+    c0 = Circuit(2).H(0).CX(0, 1)
     b = CirqStateSimBackend()
-    state = b.get_state(c)
-    assert np.allclose(state, [math.sqrt(0.5), 0, 0, math.sqrt(0.5)], atol=1e-10)
-    c.add_phase(0.5)
-    state1 = b.get_state(c)
-    assert np.allclose(state1, state * 1j, atol=1e-10)
+    state0 = b.get_state(c0)
+    assert np.allclose(state0, [math.sqrt(0.5), 0, 0, math.sqrt(0.5)], atol=1e-10)
+    c0.add_phase(0.5)
+    state1 = b.get_state(c0)
+    assert np.allclose(state1, state0 * 1j, atol=1e-10)
+    assert np.allclose(b.get_state(Circuit(2).X(1)), [0, 1.0, 0, 0], atol=1e-10)
 
 
 def test_density_matrix() -> None:

--- a/modules/pytket-cirq/tests/test_cirq_backend.py
+++ b/modules/pytket-cirq/tests/test_cirq_backend.py
@@ -38,12 +38,18 @@ def test_blank_wires() -> None:
         CirqStateSimBackend(),
     ]
     for b in backends:
-        assert b.get_result(b.process_circuit(Circuit(2).X(0))).q_bits == {Qubit(0): 0}
-        assert b.get_result(b.process_circuit(Circuit(2).X(1))).q_bits == {Qubit(1): 0}
+        assert b.get_result(b.process_circuit(Circuit(2).X(0))).q_bits == {
+            Qubit(0): 0,
+            Qubit(1): 1,
+        }
+        assert b.get_result(b.process_circuit(Circuit(2).X(1))).q_bits == {
+            Qubit(0): 0,
+            Qubit(1): 1,
+        }
         for r in b.get_result(b.process_circuit_moments(Circuit(2).X(0).X(0).X(0))):  # type: ignore
-            assert r.q_bits == {Qubit(0): 0}
+            assert r.q_bits == {Qubit(0): 0, Qubit(1): 1}
         for r in b.get_result(b.process_circuit_moments(Circuit(2).X(1).X(1).X(1))):  # type: ignore
-            assert r.q_bits == {Qubit(1): 0}
+            assert r.q_bits == {Qubit(0): 0, Qubit(1): 1}
 
     for b in [CirqDensityMatrixSampleBackend(), CirqStateSampleBackend()]:
         assert b.get_result(


### PR DESCRIPTION
Previously qubits that had no operations were not included in simulated results - this behaviour has now been changed.
In the tk_to_cirq conversion, if a qubit has no operation in the pytket circuit then it would not be present in the cirq circuit. cirq circuit objects have no 'qubits' attribute, the cirq circuit all_qubits method actually iterates through all moments, creating a frozenset of all qubits it encounters in gates. Therefore, to "add a qubit" to a circuit that has no operations, an identity gate must be added to the circuit.

To do so without tampering with the tk_to_cirq conversion code, for the moments simulators a copy of the pytket circuit for simulating is taken and identity gates are added to all qubits. When the cirq circuit is produced, even gates without any other operations on will still be present in the cirq circuit simulated.

An alternative would be to change the tk_to_cirq conversion code to add identity gates to unused qubits, though this meant the tket circuit produced by converting this cirq circuit back using cirq_to_tk would not match the original circuit. I couldn't think of a more elegant situation, so modify a copied circuit in the called simulator methods seemed better...
