### PR TITLE
Support qiskit 0.25.

### DIFF
--- a/modules/pytket-qiskit/_metadata.py
+++ b/modules/pytket-qiskit/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.9.0"
+__extension_version__ = "0.9.1"
 __extension_name__ = "pytket-qiskit"

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
@@ -664,12 +664,10 @@ def _process_model(noise_model: NoiseModel, gate_set: Set[OpType]) -> dict:
 
 
 def _sparse_to_qiskit_pauli(pauli: QubitPauliString, n_qubits: int) -> qk_Pauli:
-    empty = np.zeros(n_qubits)
-    q_pauli = qk_Pauli(empty, empty)
+    x = [False] * n_qubits
+    z = [False] * n_qubits
     for q, p in pauli.to_dict().items():
         i = _default_q_index(q)
-        if p in (Pauli.X, Pauli.Y):
-            q_pauli._x[i] = True
-        if p in (Pauli.Z, Pauli.Y):
-            q_pauli._z[i] = True
-    return q_pauli
+        z[i] = p in (Pauli.Z, Pauli.Y)
+        x[i] = p in (Pauli.X, Pauli.Y)
+    return qk_Pauli((z, x))

--- a/modules/pytket-qiskit/setup.py
+++ b/modules/pytket-qiskit/setup.py
@@ -40,7 +40,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "pytket ~= 0.9.0",
-        "qiskit ~= 0.24.0",
+        "qiskit ~= 0.25.0",
     ],
     classifiers=[
         "Environment :: Console",


### PR DESCRIPTION
Requires a small change to how we construct qiskit Pauli operators.
Closes #47.