### PR TITLE
[pytket-qiskit] Stop using aqua in tests.

### DIFF
--- a/modules/pytket-qiskit/tests/qiskit_backend_test.py
+++ b/modules/pytket-qiskit/tests/qiskit_backend_test.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
 import platform
 import numpy as np
-from pytket.backends import Backend
 from pytket.extensions.qiskit import (
     AerBackend,
     AerStateBackend,
@@ -26,11 +24,6 @@ from qiskit import QuantumCircuit, execute  # type: ignore
 from qiskit.providers import JobStatus  # type: ignore
 from qiskit.providers.aer import Aer  # type: ignore
 from qiskit.utils import QuantumInstance  # type: ignore
-
-# Memory corruption on Windows with qulacs 0.2.0 (TKET-1056)
-use_qulacs = platform.system() != "Windows"
-if use_qulacs:
-    from pytket.extensions.qulacs import QulacsBackend  # type: ignore
 
 
 def circuit_gen(measure: bool = False) -> QuantumCircuit:

--- a/modules/pytket-qiskit/tests/qiskit_backend_test.py
+++ b/modules/pytket-qiskit/tests/qiskit_backend_test.py
@@ -25,7 +25,7 @@ from pytket.extensions.qiskit.tket_backend import TketBackend
 from qiskit import QuantumCircuit, execute  # type: ignore
 from qiskit.providers import JobStatus  # type: ignore
 from qiskit.providers.aer import Aer  # type: ignore
-from qiskit.aqua import QuantumInstance  # type: ignore
+from qiskit.utils import QuantumInstance  # type: ignore
 from qiskit.aqua.algorithms import BernsteinVazirani, DeutschJozsa  # type: ignore
 from qiskit.aqua.components.oracles import TruthTableOracle  # type: ignore
 

--- a/modules/pytket-qiskit/tests/qiskit_backend_test.py
+++ b/modules/pytket-qiskit/tests/qiskit_backend_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import platform
 import numpy as np
 from pytket.extensions.qiskit import (
     AerBackend,

--- a/modules/pytket-qiskit/tests/qiskit_backend_test.py
+++ b/modules/pytket-qiskit/tests/qiskit_backend_test.py
@@ -26,8 +26,6 @@ from qiskit import QuantumCircuit, execute  # type: ignore
 from qiskit.providers import JobStatus  # type: ignore
 from qiskit.providers.aer import Aer  # type: ignore
 from qiskit.utils import QuantumInstance  # type: ignore
-from qiskit.aqua.algorithms import BernsteinVazirani, DeutschJozsa  # type: ignore
-from qiskit.aqua.components.oracles import TruthTableOracle  # type: ignore
 
 # Memory corruption on Windows with qulacs 0.2.0 (TKET-1056)
 use_qulacs = platform.system() != "Windows"
@@ -82,28 +80,6 @@ def test_unitary() -> None:
         job2 = execute(qc, qb)
         u2 = job2.result().get_unitary()
         assert np.allclose(u, u2)
-
-
-def test_aqua_algorithm() -> None:
-    backends: List[Backend] = [AerBackend(), AerStateBackend()]
-    if use_qulacs:
-        backends.append(QulacsBackend())
-    for b in backends:
-        for comp in (None, b.default_compilation_pass()):
-            if use_qulacs and type(b) == QulacsBackend and comp is None:
-                continue
-            tb = TketBackend(b, comp)
-            ora = TruthTableOracle(bitmaps="01100110")
-            alg = BernsteinVazirani(oracle=ora, quantum_instance=tb)
-            result = alg.run()
-            assert result["result"] == "011"
-            alg = DeutschJozsa(oracle=ora, quantum_instance=tb)
-            result = alg.run()
-            assert result["result"] == "balanced"
-            ora = TruthTableOracle(bitmaps="11111111")
-            alg = DeutschJozsa(oracle=ora, quantum_instance=tb)
-            result = alg.run()
-            assert result["result"] == "constant"
 
 
 def test_cancel() -> None:

--- a/modules/pytket-qiskit/tests/qiskit_convert_test.py
+++ b/modules/pytket-qiskit/tests/qiskit_convert_test.py
@@ -27,7 +27,6 @@ from qiskit import (  # type: ignore
 )
 from qiskit.opflow import PauliTrotterEvolution  # type: ignore
 from qiskit.opflow.primitive_ops import PauliSumOp  # type: ignore
-from qiskit.quantum_info import Pauli  # type: ignore
 from qiskit.transpiler import PassManager  # type: ignore
 from qiskit.circuit.library import RYGate, MCMT  # type: ignore
 from pytket.circuit import (  # type: ignore

--- a/modules/pytket-qiskit/tests/test-requirements.txt
+++ b/modules/pytket-qiskit/tests/test-requirements.txt
@@ -1,1 +1,0 @@
-pytket-qulacs


### PR DESCRIPTION
* Rewrite one test to use `PauliSumOp` instead of `WeightedPauliOperator`.
* Remove a test that uses algorithms no longer provided by qiskit (the `TketBackend` is tested elsewhere so hopefully we don't lose much by doing this).

Closes #15.