### PR TITLE
[bugfix][pytket-cirq][tket-1240] Raise ValueError if n_shots not appropriate for _CirqSampleBackend

### DIFF
--- a/modules/pytket-cirq/pytket/extensions/cirq/backends/cirq.py
+++ b/modules/pytket-cirq/pytket/extensions/cirq/backends/cirq.py
@@ -146,6 +146,8 @@ class _CirqSampleBackend(_CirqBaseBackend):
         valid_check: bool = True,
         **kwargs: KwargTypes,
     ) -> List[ResultHandle]:
+        if n_shots is None or n_shots < 1:
+            raise ValueError("Parameter n_shots is required for this backend")
         self._simulator = self.set_simulator(seed=kwargs.get("seed"))
         circuit_list = list(circuits)
         if valid_check:


### PR DESCRIPTION
_CirqSampleBackend always requires a number of shots regardless of how results are produced.
For other backends where this is the case, the `process_circuits` method will raise a ValueError if n_shots is not set, or is set inappropriately. 
Currently _CirqSampleBackend does not do this, but Isobel has correctly pointed out that it probably should.
So now it does.

