### PR TITLE
[pytket-aqt][bugfix] Fixed RebaseAQT

### DIFF
--- a/modules/pytket-aqt/pytket/extensions/aqt/backends/aqt.py
+++ b/modules/pytket-aqt/pytket/extensions/aqt/backends/aqt.py
@@ -319,12 +319,13 @@ def _translate_aqt(circ: Circuit) -> Tuple[List[List], str]:
 def _aqt_rebase() -> BasePass:
     # CX replacement
     c_cx = Circuit(2)
-    c_cx.Ry(0.5, 0)
-    c_cx.add_gate(OpType.XXPhase, 0.5, [0, 1])
-    c_cx.Ry(1.0, 0).Rx(-0.5, 0).Ry(0.5, 0)
+    c_cx.Ry(0.5, 0).Rx(0.5, 0)
     c_cx.Rx(-0.5, 1)
+    c_cx.add_gate(OpType.XXPhase, 0.5, [0, 1])
+    c_cx.Ry(0.5, 0).Rx(-1, 0)
+    c_cx.add_phase(-0.25)
 
     # TK1 replacement
-    c_tk1 = lambda a, b, c: Circuit(1).Rx(-0.5, 0).Ry(a, 0).Rx(b, 0).Ry(c, 0).Rx(0.5, 0)
+    c_tk1 = lambda a, b, c: Circuit(1).Rx(-0.5, 0).Ry(c, 0).Rx(b, 0).Ry(a, 0).Rx(0.5, 0)
 
     return RebaseCustom({OpType.XXPhase}, c_cx, {OpType.Rx, OpType.Ry}, c_tk1)

--- a/modules/pytket-aqt/tests/convert_test.py
+++ b/modules/pytket-aqt/tests/convert_test.py
@@ -57,9 +57,41 @@ def test_convert() -> None:
     assert all(gate[0] in ["X", "Y", "MS"] for gate in circ_aqt[0])
 
 
-def test_rebase() -> None:
+def test_rebase_CX() -> None:
     circ = Circuit(2)
     circ.CX(0, 1)
+    orig_circ = circ.copy()
+
+    _aqt_rebase().apply(circ)
+
+    # TODO use tketsim for this test once available
+    u1 = AerUnitaryBackend().get_unitary(orig_circ)
+    u2 = AerUnitaryBackend().get_unitary(circ)
+
+    assert np.allclose(u1, u2)
+
+
+def test_rebase_singleq() -> None:
+    circ = Circuit(1)
+    # some arbitrary unitary
+    circ.add_gate(OpType.U3, [0.01231, 0.848, 38.200], [0])
+    orig_circ = circ.copy()
+
+    _aqt_rebase().apply(circ)
+
+    # TODO use tketsim for this test once available
+    u1 = AerUnitaryBackend().get_unitary(orig_circ)
+    u2 = AerUnitaryBackend().get_unitary(circ)
+
+    assert np.allclose(u1, u2)
+
+
+def test_rebase_large() -> None:
+    circ = Circuit(3)
+    # some arbitrary unitary
+    circ.Rx(0.21, 0).Rz(0.12, 1).Rz(8.2, 2).X(2).CX(0, 1).CX(1, 2).Rz(0.44, 1).Rx(
+        0.43, 0
+    )
     orig_circ = circ.copy()
 
     _aqt_rebase().apply(circ)

--- a/modules/pytket-aqt/tests/test-requirements.txt
+++ b/modules/pytket-aqt/tests/test-requirements.txt
@@ -1,0 +1,1 @@
+pytket-qiskit


### PR DESCRIPTION
The rebase to the AQT gate set was wrong, for both single qubit and two qubit replacements.