### PR TITLE
[pytket-qiskit] Test equality of sets.

### DIFF
--- a/modules/pytket-qiskit/tests/backend_test.py
+++ b/modules/pytket-qiskit/tests/backend_test.py
@@ -229,19 +229,21 @@ def test_process_characterisation_incomplete_noise_model() -> None:
         char.get("Architecture", Architecture([])),
     )
     nodes = dev.nodes
-    assert dev.architecture.coupling == [
-        (nodes[0], nodes[1]),
-        (nodes[0], nodes[2]),
-        (nodes[0], nodes[3]),
-        (nodes[1], nodes[2]),
-        (nodes[1], nodes[3]),
-        (nodes[2], nodes[0]),
-        (nodes[2], nodes[1]),
-        (nodes[2], nodes[3]),
-        (nodes[3], nodes[0]),
-        (nodes[3], nodes[1]),
-        (nodes[3], nodes[2]),
-    ]
+    assert set(dev.architecture.coupling) == set(
+        [
+            (nodes[0], nodes[1]),
+            (nodes[0], nodes[2]),
+            (nodes[0], nodes[3]),
+            (nodes[1], nodes[2]),
+            (nodes[1], nodes[3]),
+            (nodes[2], nodes[0]),
+            (nodes[2], nodes[1]),
+            (nodes[2], nodes[3]),
+            (nodes[3], nodes[0]),
+            (nodes[3], nodes[1]),
+            (nodes[3], nodes[2]),
+        ]
+    )
 
 
 def test_circuit_compilation_complete_noise_model() -> None:


### PR DESCRIPTION
The order is irrelevant, and with recent changes on pytket develop branch this test currently fails because the coupling is stored in a different order.