### PR TITLE
[pytket-cirq] [hotfix] Make cirq version requirement more strict.

### DIFF
--- a/modules/pytket-cirq/_metadata.py
+++ b/modules/pytket-cirq/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.10.0"
+__extension_version__ = "0.10.1"
 __extension_name__ = "pytket-cirq"

--- a/modules/pytket-cirq/setup.py
+++ b/modules/pytket-cirq/setup.py
@@ -38,7 +38,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 0.10.0", "cirq ~= 0.10"],
+    install_requires=["pytket ~= 0.10.0", "cirq ~= 0.10.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
See #79.