### PR TITLE
add CH gate

### DIFF
--- a/modules/pytket-cirq/pytket/extensions/cirq/cirq_convert.py
+++ b/modules/pytket-cirq/pytket/extensions/cirq/cirq_convert.py
@@ -52,6 +52,7 @@ _cirq2ops_mapping = {
     cirq.ops.I: OpType.noop,
     cirq_common.CZPowGate: OpType.CU1,
     cirq_common.CZ: OpType.CZ,
+    cirq_common.H.controlled(1): OpType.CH,
     cirq.ops.CSwapGate: OpType.CSWAP,
     cirq_common.ISwapPowGate: OpType.ISWAP,
     cirq_common.ISWAP: OpType.ISWAPMax,


### PR DESCRIPTION
A minimal example:
``` 
qc=QuantumCircuit(2)
qc.h(0)
qc.ch(0,1)
cc=qiskit_to_cirq(qc)
print(qc)
print(cc)
```
