### PR TITLE
Using a forked sphinx 4.0.1. 

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx
+git+git://github.com/yao-cqc/sphinx.git@ignore-mutated-finders-in-autodoc
 sphinx_rtd_theme


### PR DESCRIPTION
This PR should fix #84.

In Sphinx autodoc v4.0.1, if a program mutate `sys.meta_path` then the `sys.meta_path.remove(finder)` in this [line](https://github.com/sphinx-doc/sphinx/blob/bdce720bb9f69d1c39ed14d214e15db4df341805/sphinx/ext/autodoc/mock.py#L151) might fail (raise a ValueError). Unfortunately, Cirq 0.11.0 does [exactly](https://github.com/quantumlib/Cirq/blob/58e16054159af6719825ada1d477b3b6d95204c5/cirq-core/cirq/_compat.py#L557) that to handle depracated modules.

This PR uses a [forked](https://github.com/yao-cqc/sphinx/blob/7691d43d0aebe1f339e4bd2704d2237295507fa1/sphinx/ext/autodoc/mock.py#L151) Sphinx v4.0.1 that ignores the exception rased by `sys.meta_path.remove(finder)`. Not removing the mock finders should only affect the speed of importing modules. (i.e. the `sys.meta_path` keeps getting larger, a _guess_ according to [this](https://docs.python.org/3/library/sys.html#sys.meta_path))

Another possible fix is to use a forked Cirq 0.11.0 with [this line](https://github.com/quantumlib/Cirq/blob/58e16054159af6719825ada1d477b3b6d95204c5/cirq-core/cirq/_compat.py#L557) removed only for building the `pytket-cirq` docs; but then the fork needs to be updated for every Cirq release.