### PR TITLE
[pytket-braket] Allow BraketBackend to take an AwsSession

### DIFF
--- a/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
+++ b/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
@@ -220,7 +220,8 @@ class BraketBackend(Backend):
             default: "quantum-simulator"
         :param provider: provider name from device ARN (e.g. "ionq", "rigetti", ...),
             default: "amazon"
-        :param aws_session: braket AwsSession object, to pass credentials in
+        :param aws_session: braket AwsSession object, to pass credentials in if not
+            configured on local machine
         """
         super().__init__()
         # load config


### PR DESCRIPTION
Resolves #90.

BraketBackend can now take a `braket.aws.AwsSession` object, which itself can take a `boto3.Session` object. Since we [can pass AWS credentials to the `boto3.Session` object](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#passing-credentials-as-parameters), this means we can use BraketBackend without having credentials set as environment variables (as the AWS CLI does).

If the user doesn't pass an AwsSession object, BraketBackend behaves as it did before (with braket's internal code creating sessions as needed).

----

I've tested this using the Amazon Braket SV1 simulator in us-west-1 (without any other AWS credentials configured) and it seems to work okay. I'm not sure that it would help much to add a unit test in for this functionality as the remote tests aren't run by default, but it'd be relatively easy to test manually.