### PR TITLE
Require version of openfermion compatible with cirq 0.11.

### DIFF
--- a/.github/workflows/build-test
+++ b/.github/workflows/build-test
@@ -49,7 +49,7 @@ for MODULE in $MODULES_TO_TEST; do
 
     cd ${MODULEDIR}/${MODULE}/tests
 
-    python -m pip install -r test-requirements.txt
+    python -m pip install --pre -r test-requirements.txt
 
     if [[ "${MODULE}" = "pytket-qsharp" && "${PLAT}" != "Darwin" ]]
     then

--- a/modules/pytket-qulacs/tests/test-requirements.txt
+++ b/modules/pytket-qulacs/tests/test-requirements.txt
@@ -1,1 +1,1 @@
-openfermion
+git+git://github.com/quantumlib/OpenFermion@086073666d275de736861b41ed535a9fe75e63ac#egg=openfermion


### PR DESCRIPTION
This prevents the problem of qulacs tests forcing a downgrade of cirq, which then has to be upgraded to run cirq tests, which then fail because the upgrade from cirq 0.10 to cirq 0.11 on Linux is broken.