### PR TITLE
Explicitly disallow non-Hermitian operators where they're not supported.

### DIFF
--- a/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
+++ b/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
@@ -250,6 +250,7 @@ class ForestBackend(Backend):
 class ForestStateBackend(Backend):
     _supports_state = True
     _supports_expectation = True
+    _expectation_allows_nonhermitian = False
     _persistent_handles = False
 
     def __init__(self) -> None:

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
@@ -535,6 +535,7 @@ class AerBackend(_AerBaseBackend):
 class AerStateBackend(_AerStateBaseBackend):
     _supports_state = True
     _supports_expectation = True
+    _expectation_allows_nonhermitian = False
 
     def __init__(self) -> None:
         """Backend for running simulations on the Qiskit Aer Statevector simulator."""

--- a/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
+++ b/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
@@ -74,6 +74,7 @@ class QulacsBackend(Backend):
     _supports_counts = True
     _supports_state = True
     _supports_expectation = True
+    _expectation_allows_nonhermitian = False
     _persistent_handles = False
 
     def __init__(self) -> None:


### PR DESCRIPTION
(Which happens to be everywhere now,)