### PR TITLE
[pytket-braket] Add @property decorator to BraketBackend.device

### DIFF
--- a/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
+++ b/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
@@ -562,6 +562,7 @@ class BraketBackend(Backend):
     def characterisation(self) -> Optional[Dict]:
         return self._characteristics
 
+    @property
     def device(self) -> Optional[Device]:
         return self._tket_device
 

--- a/modules/pytket-braket/tests/backend_test.py
+++ b/modules/pytket-braket/tests/backend_test.py
@@ -81,7 +81,7 @@ def test_ionq() -> None:
     assert not b.supports_state
 
     # Device is fully connected
-    dev = b.device()
+    dev = b.device
     assert dev is not None
     arch = dev.architecture
     n = len(arch.nodes)


### PR DESCRIPTION
Fixes #102. 

This matches the definition of `.device` in other Backend classes.