### PR TITLE
[pytket-aqt] [pytket-qsharp] Make AQTBackend and AzureBackend handle cache updates more robustly

### DIFF
--- a/modules/pytket-qsharp/pytket/extensions/qsharp/backends/azure_quantum.py
+++ b/modules/pytket-qsharp/pytket/extensions/qsharp/backends/azure_quantum.py
@@ -71,6 +71,7 @@ class AzureBackend(_QsharpBaseBackend):
 
     _supports_counts = True
     _supports_contextual_optimisation = True
+    _persistent_handles = True
 
     def __init__(
         self,


### PR DESCRIPTION
In these backends' `circuit_status()` method, we previously assumed that self._cache[handle] would already have been set.

This is not always the case (a different backend instance could be used used to run .process_circuits() and .circuit_status()).

This change makes setting the result in the cache more robust.

This is the same fix as was done in #107, but for other backends that had the same bug.