### PR TITLE
[hotfix] [pytket-qiskit] [pytket-ionq] fix #128

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Update pip
       run: pip install --upgrade pip
     - name: Install black and pylint
-      run: pip install black~=20.8b1 pylint
+      run: pip install black~=21.6b0 pylint
     - name: Check files are formatted with black
       run: |
         black --check modules/

--- a/modules/pytket-ionq/_metadata.py
+++ b/modules/pytket-ionq/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.8.0"
+__extension_version__ = "0.8.1"
 __extension_name__ = "pytket-ionq"

--- a/modules/pytket-ionq/docs/changelog.rst
+++ b/modules/pytket-ionq/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+0.8.1 (July 2021)
+-----------------
+
+* Fixed bug in IonQBackend when n_shots argument was passed as list.
+
 0.8.0 (June 2021)
 -----------------
 

--- a/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq.py
+++ b/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq.py
@@ -242,7 +242,6 @@ class IonQBackend(Backend):
                     measures,
                     json.dumps(ppcirc_rep),
                 )
-                handles.append(handle)
             else:
                 header = self._header.copy()
                 header["Content-Type"] = "application/json"
@@ -261,8 +260,7 @@ class IonQBackend(Backend):
                 # extract job ID from response
                 job_id = resp["id"]
                 handle = ResultHandle(job_id, n_shots, measures, json.dumps(ppcirc_rep))
-                handles.append(handle)
-        for handle in handles:
+            handles.append(handle)
             self._cache[handle] = result
         return handles
 

--- a/modules/pytket-projectq/_metadata.py
+++ b/modules/pytket-projectq/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.11.0"
+__extension_version__ = "0.11.1"
 __extension_name__ = "pytket-projectq"

--- a/modules/pytket-projectq/docs/changelog.rst
+++ b/modules/pytket-projectq/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+0.11.1 (unreleased)
+-------------------
+
+* Updated projectq version requirement to 0.6.
+
 0.11.0 (June 2021)
 ------------------
 

--- a/modules/pytket-projectq/setup.py
+++ b/modules/pytket-projectq/setup.py
@@ -38,7 +38,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 0.12.0", "projectq ~= 0.5.0"],
+    install_requires=["pytket ~= 0.12.0", "projectq ~= 0.6.1"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.7",

--- a/modules/pytket-qiskit/_metadata.py
+++ b/modules/pytket-qiskit/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.15.0"
+__extension_version__ = "0.15.1"
 __extension_name__ = "pytket-qiskit"

--- a/modules/pytket-qiskit/docs/changelog.rst
+++ b/modules/pytket-qiskit/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+0.15.1 (July 2021)
+------------------
+
+* Fixed bug in backends when n_shots argument was passed as list.
+
 0.15.0 (June 2021)
 ------------------
 

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
@@ -192,10 +192,9 @@ class _AerBaseBackend(Backend):
             )
             jobid = job.job_id()
             for i, ind in enumerate(indices):
-                handle_list[ind] = ResultHandle(jobid, i)
-        for handle in handle_list:
-            assert handle is not None
-            self._cache[handle] = {"job": job}
+                handle = ResultHandle(jobid, i)
+                handle_list[ind] = handle
+                self._cache[handle] = {"job": job}
         return cast(List[ResultHandle], handle_list)
 
     def cancel(self, handle: ResultHandle) -> None:

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -158,10 +158,9 @@ class IBMQEmulatorBackend(AerBackend):
             )
             jobid = job.job_id()
             for i, ind in enumerate(indices):
-                handle_list[ind] = ResultHandle(jobid, i, ppcirc_strs[i])
-        for handle in handle_list:
-            assert handle is not None
-            self._cache[handle] = {"job": job}
+                handle = ResultHandle(jobid, i, ppcirc_strs[i])
+                handle_list[ind] = handle
+                self._cache[handle] = {"job": job}
         return cast(List[ResultHandle], handle_list)
 
     def get_result(self, handle: ResultHandle, **kwargs: KwargTypes) -> BackendResult:

--- a/modules/pytket-qiskit/tests/backend_test.py
+++ b/modules/pytket-qiskit/tests/backend_test.py
@@ -401,6 +401,21 @@ def test_nshots_batching(santiago_backend: IBMQBackend) -> None:
         backend._MACHINE_DEBUG = False
 
 
+def test_nshots() -> None:
+    backends = [AerBackend()]
+    if not skip_remote_tests:
+        backends.append(
+            IBMQEmulatorBackend(
+                "ibmq_santiago", hub="ibm-q", group="open", project="main"
+            )
+        )
+    for b in backends:
+        circuit = Circuit(1)
+        n_shots = [1, 2, 3]
+        results = b.get_results(b.process_circuits([circuit] * 3, n_shots=n_shots))
+        assert [len(r.get_shots()) for r in results] == n_shots
+
+
 def test_pauli_statevector() -> None:
     c = Circuit(2)
     c.Rz(0.5, 0)


### PR DESCRIPTION
This is for a hotfix solving bug #128

All remote tests for `pytket-qiskit` and `pytket-ionq` are passing.