### PR TITLE
Update use of BackendInfo to reflect pytket/Mushroom requests

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,6 @@ from typing import Any, Dict, List, Optional
 
 # Mappings for broken hyperlinks that intersphinx cannot resolve
 external_url_mapping = {
-    "Device": urljoin(pytketdoc_base, "device.html#pytket.device.Device"),
     "BasePass": urljoin(pytketdoc_base, "passes.html#pytket.passes.BasePass"),
     "Predicate": urljoin(pytketdoc_base, "predicates.html#pytket.predicates.Predicate"),
     "ResultHandle": urljoin(

--- a/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
+++ b/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
@@ -423,13 +423,9 @@ class BraketBackend(Backend):
                 __extension_version__,
                 arch,
                 self._singleqs.union(self._multiqs),
-                misc={
-                    "characterisation": {
-                        "NodeErrors": node_errors,
-                        "EdgeErrors": link_errors,
-                        "ReadoutErrors": readout_errors,
-                    }
-                },
+                all_node_gate_errors=node_errors,
+                all_edge_gate_errors=link_errors,
+                all_readout_errors=readout_errors,
             )
         else:
             self._backend_info = BackendInfo(

--- a/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
+++ b/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
@@ -117,12 +117,8 @@ class ForestBackend(Backend):
             __extension_version__,
             arch,
             self._GATE_SET,
-            misc={
-                "characterisation": {
-                    "NodeErrors": node_errors,
-                    "EdgeErrors": link_errors,
-                }
-            },
+            all_node_gate_errors=node_errors,
+            all_edge_gate_errors=link_errors,
         )
 
     @property

--- a/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
+++ b/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
@@ -120,8 +120,8 @@ class ForestBackend(Backend):
             self._GATE_SET,
             all_node_gate_errors=node_errors,
             all_edge_gate_errors=link_errors,
-            averaged_node_errors=averaged_errors["node_errors"],
-            averaged_edge_errors=averaged_errors["link_errors"],
+            averaged_node_gate_errors=averaged_errors["node_errors"],
+            averaged_edge_gate_errors=averaged_errors["link_errors"],
         )
 
     @property

--- a/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
+++ b/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
@@ -111,6 +111,7 @@ class ForestBackend(Backend):
         arch = char_dict.get("Architecture", Architecture([]))
         node_errors = char_dict.get("NodeErrors")
         link_errors = char_dict.get("EdgeErrors")
+        averaged_errors = get_avg_characterisation(char_dict)
         self._backend_info = BackendInfo(
             type(self).__name__,
             qc_name,
@@ -119,6 +120,8 @@ class ForestBackend(Backend):
             self._GATE_SET,
             all_node_gate_errors=node_errors,
             all_edge_gate_errors=link_errors,
+            averaged_node_errors=averaged_errors["node_errors"],
+            averaged_edge_errors=averaged_errors["edge_errors"],
         )
 
     @property

--- a/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
+++ b/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
@@ -14,7 +14,7 @@
 
 import json
 from copy import copy
-from typing import cast, Any, Dict, Iterable, List, Optional, Sequence, Union
+from typing import cast, Iterable, List, Optional, Sequence, Union
 from uuid import uuid4
 from logging import warning
 

--- a/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
+++ b/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
@@ -121,7 +121,7 @@ class ForestBackend(Backend):
             all_node_gate_errors=node_errors,
             all_edge_gate_errors=link_errors,
             averaged_node_errors=averaged_errors["node_errors"],
-            averaged_edge_errors=averaged_errors["edge_errors"],
+            averaged_edge_errors=averaged_errors["link_errors"],
         )
 
     @property

--- a/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
+++ b/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
@@ -148,8 +148,9 @@ class ForestBackend(Backend):
             CXMappingPass(
                 self.backend_info.architecture,
                 NoiseAwarePlacement(
-                    self.backend_info.architecture,
-                    **get_avg_characterisation(self.characterisation),
+                    self._backend_info.architecture,
+                    self._backend_info.averaged_node_gate_errors,
+                    self._backend_info.averaged_edge_gate_errors,
                 ),
                 directed_cx=False,
                 delay_measures=True,
@@ -265,11 +266,6 @@ class ForestBackend(Backend):
             )
             self._cache[handle].update({"result": res})
             return res
-
-    @property
-    def characterisation(self) -> Dict[str, Any]:
-        char = self._backend_info.get_misc("characterisation")
-        return cast(Dict[str, Any], char)
 
     @property
     def backend_info(self) -> BackendInfo:

--- a/modules/pytket-pyquil/tests/qvm_backend_test.py
+++ b/modules/pytket-pyquil/tests/qvm_backend_test.py
@@ -138,12 +138,12 @@ def test_pauli_statevector(qvm: None, quilc: None) -> None:
 @pytest.mark.skipif(
     skip_qvm_tests, reason="Can only run Rigetti QVM if docker is installed"
 )
-def test_characterisation(qvm: None, quilc: None) -> None:
+def test_backendinfo(qvm: None, quilc: None) -> None:
     b = ForestBackend("9q-square")
-    char = b.characterisation
-    assert char
-    assert len(char["NodeErrors"]) == 9
-    assert len(char["EdgeErrors"]) == 12
+    bi = b.backend_info
+    assert bi
+    assert len(bi.all_node_gate_errors) == 9
+    assert len(bi.all_edge_gate_errors) == 12
     assert b.backend_info.architecture
 
 

--- a/modules/pytket-pyquil/tests/qvm_backend_test.py
+++ b/modules/pytket-pyquil/tests/qvm_backend_test.py
@@ -18,7 +18,7 @@ from collections import Counter
 from shutil import which
 import platform
 
-from typing import cast
+from typing import cast, Dict
 import docker  # type: ignore
 import numpy as np
 import pytest
@@ -141,9 +141,12 @@ def test_pauli_statevector(qvm: None, quilc: None) -> None:
 def test_backendinfo(qvm: None, quilc: None) -> None:
     b = ForestBackend("9q-square")
     bi = b.backend_info
+    node_gate_errors = cast(Dict, bi.all_node_gate_errors)
+    edge_gate_errors = cast(Dict, bi.all_edge_gate_errors)
+
     assert bi
-    assert len(bi.all_node_gate_errors) == 9
-    assert len(bi.all_edge_gate_errors) == 12
+    assert len(node_gate_errors) == 9
+    assert len(edge_gate_errors) == 12
     assert b.backend_info.architecture
 
 

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
@@ -505,9 +505,9 @@ class AerBackend(_AerBaseBackend):
                     arch,
                     NoiseAwarePlacement(
                         arch,
-                        self._backend_info.averaged_node_errors,
-                        self._backend_info.averaged_edge_errors,
-                        self._backend_info.averaged_readout_errors,
+                        self._backend_info.averaged_node_gate_errors,
+                        self._backend_info.averaged_edge_gate_errors,
+                        self._backend_info.averaged_readout_gate_errors,
                     ),
                     directed_cx=True,
                     delay_measures=False,

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
@@ -507,7 +507,7 @@ class AerBackend(_AerBaseBackend):
                         arch,
                         self._backend_info.averaged_node_gate_errors,
                         self._backend_info.averaged_edge_gate_errors,
-                        self._backend_info.averaged_readout_gate_errors,
+                        self._backend_info.averaged_readout_errors,
                     ),
                     directed_cx=True,
                     delay_measures=False,

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
@@ -436,14 +436,15 @@ class AerBackend(_AerBaseBackend):
 
             arch = characterisation["Architecture"]
             self._backend_info.architecture = arch
-            self._backend_info.all_node_gate_errors=characterisation["NodeErrors"]
-            self._backend_info.all_edge_gate_errors=characterisation["EdgeErrors"]
-            self._backend_info.all_readout_errors=characterisation["ReadoutErrors"]
+            self._backend_info.all_node_gate_errors = characterisation["NodeErrors"]
+            self._backend_info.all_edge_gate_errors = characterisation["EdgeErrors"]
+            self._backend_info.all_readout_errors = characterisation["ReadoutErrors"]
 
-            self._backend_info.averaged_node_errors=averaged_errors["node_errors"]
-            self._backend_info.averaged_edge_errors=averaged_errors["edge_errors"]
-            self._backend_info.averaged_readout_errors=averaged_errors["readout_errors"]
-
+            self._backend_info.averaged_node_errors = averaged_errors["node_errors"]
+            self._backend_info.averaged_edge_errors = averaged_errors["edge_errors"]
+            self._backend_info.averaged_readout_errors = averaged_errors[
+                "readout_errors"
+            ]
 
             characterisation_keys = [
                 "GenericOneQubitQErrors",

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
@@ -433,15 +433,18 @@ class AerBackend(_AerBaseBackend):
         else:
             self._noise_model = noise_model
             characterisation = _process_model(noise_model, self._backend_info.gate_set)
+            averaged_errors = get_avg_characterisation(characterisation)
 
             arch = characterisation["Architecture"]
             self._backend_info.architecture = arch
-            self._backend_info.all_node_gate_errors=characterisation["NodeErrors"],
-            self._backend_info.all_edge_gate_errors=characterisation["EdgeErrors"],
-            self._backend_info.all_readout_errors=characterisation["ReadoutErrors"],
-            self._backend_info.averaged_node_errors=averaged_errors["node_errors"],
-            self._backend_info.averaged_edge_errors=averaged_errors["edge_errors"],
+            self._backend_info.all_node_gate_errors=characterisation["NodeErrors"]
+            self._backend_info.all_edge_gate_errors=characterisation["EdgeErrors"]
+            self._backend_info.all_readout_errors=characterisation["ReadoutErrors"]
+
+            self._backend_info.averaged_node_errors=averaged_errors["node_errors"]
+            self._backend_info.averaged_edge_errors=averaged_errors["edge_errors"]
             self._backend_info.averaged_readout_errors=averaged_errors["readout_errors"]
+
 
             characterisation_keys = [
                 "GenericOneQubitQErrors",
@@ -498,8 +501,8 @@ class AerBackend(_AerBaseBackend):
                     arch,
                     NoiseAwarePlacement(
                         arch,
-                        self._backend_info.averaged_node_gate_errors,
-                        self._backend_info.averaged_edge_gate_errors,
+                        self._backend_info.averaged_node_errors,
+                        self._backend_info.averaged_edge_errors,
                         self._backend_info.averaged_readout_errors,
                     ),
                     directed_cx=True,

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
@@ -433,10 +433,17 @@ class AerBackend(_AerBaseBackend):
         else:
             self._noise_model = noise_model
             characterisation = _process_model(noise_model, self._backend_info.gate_set)
+
+            arch = characterisation["Architecture"]
+            self._backend_info.architecture = arch
+            self._backend_info.all_node_gate_errors=characterisation["NodeErrors"],
+            self._backend_info.all_edge_gate_errors=characterisation["EdgeErrors"],
+            self._backend_info.all_readout_errors=characterisation["ReadoutErrors"],
+            self._backend_info.averaged_node_errors=averaged_errors["node_errors"],
+            self._backend_info.averaged_edge_errors=averaged_errors["edge_errors"],
+            self._backend_info.averaged_readout_errors=averaged_errors["readout_errors"]
+
             characterisation_keys = [
-                "NodeErrors",
-                "EdgeErrors",
-                "ReadoutErrors",
                 "GenericOneQubitQErrors",
                 "GenericTwoQubitQErrors",
             ]
@@ -445,9 +452,8 @@ class AerBackend(_AerBaseBackend):
             characterisation = {
                 k: v for k, v in characterisation.items() if k in characterisation_keys
             }
-
-            self._backend_info.architecture = arch
             self._backend_info.misc["characterisation"] = characterisation
+
         self._memory = True
 
         self._backend.set_options(method=simulation_method)
@@ -491,7 +497,10 @@ class AerBackend(_AerBaseBackend):
                 CXMappingPass(
                     arch,
                     NoiseAwarePlacement(
-                        arch, **get_avg_characterisation(self.characterisation)
+                        arch,
+                        self._backend_info.averaged_node_gate_errors,
+                        self._backend_info.averaged_edge_gate_errors,
+                        self._backend_info.averaged_readout_errors,
                     ),
                     directed_cx=True,
                     delay_measures=False,

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
@@ -440,8 +440,12 @@ class AerBackend(_AerBaseBackend):
             self._backend_info.all_edge_gate_errors = characterisation["EdgeErrors"]
             self._backend_info.all_readout_errors = characterisation["ReadoutErrors"]
 
-            self._backend_info.averaged_node_errors = averaged_errors["node_errors"]
-            self._backend_info.averaged_edge_errors = averaged_errors["edge_errors"]
+            self._backend_info.averaged_node_gate_errors = averaged_errors[
+                "node_errors"
+            ]
+            self._backend_info.averaged_edge_gate_errors = averaged_errors[
+                "edge_errors"
+            ]
             self._backend_info.averaged_readout_errors = averaged_errors[
                 "readout_errors"
             ]

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibm.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibm.py
@@ -73,7 +73,7 @@ from pytket.extensions.qiskit.qiskit_convert import tk_to_qiskit, _tk_gate_set
 from pytket.extensions.qiskit.result_convert import (
     qiskit_experimentresult_to_backendresult,
 )
-from pytket.routing import NoiseAwarePlacement # type: ignore
+from pytket.routing import NoiseAwarePlacement  # type: ignore
 from pytket.utils import prepare_circuit
 from pytket.utils.results import KwargTypes
 from .ibm_utils import _STATUS_MAP, _batch_circuits
@@ -383,7 +383,7 @@ class IBMQBackend(Backend):
             CXMappingPass(
                 arch,
                 NoiseAwarePlacement(
-                    arch, 
+                    arch,
                     self._backend_info.averaged_node_gate_errors,
                     self._backend_info.averaged_edge_gate_errors,
                     self._backend_info.averaged_readout_errors,

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibm.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibm.py
@@ -311,8 +311,8 @@ class IBMQBackend(Backend):
             all_node_gate_errors=characterisation["NodeErrors"],
             all_edge_gate_errors=characterisation["EdgeErrors"],
             all_readout_errors=characterisation["ReadoutErrors"],
-            averaged_node_errors=averaged_errors["node_errors"],
-            averaged_edge_errors=averaged_errors["edge_errors"],
+            averaged_node_gate_errors=averaged_errors["node_errors"],
+            averaged_edge_gate_errors=averaged_errors["edge_errors"],
             averaged_readout_errors=averaged_errors["readout_errors"],
             misc={"characterisation": filtered_characterisation},
         )

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
@@ -657,6 +657,6 @@ def get_avg_characterisation(
 
     return {
         "node_errors": avg_node_errors,
-        "link_errors": avg_link_errors,
+        "edge_errors": avg_link_errors,
         "readout_errors": avg_readout_errors,
     }

--- a/modules/pytket-qiskit/tests/backend_test.py
+++ b/modules/pytket-qiskit/tests/backend_test.py
@@ -306,14 +306,16 @@ def test_process_characterisation_complete_noise_model() -> None:
     link_errors = back.backend_info.all_edge_gate_errors
     arch = back.backend_info.architecture
 
-    assert char["GenericTwoQubitQErrors"][(0, 1)][0][1][0] == 0.0375
-    assert char["GenericTwoQubitQErrors"][(0, 1)][0][1][15] == 0.4375
-    assert char["GenericOneQubitQErrors"][0][0][1][0] == 0.125
-    assert char["GenericOneQubitQErrors"][0][0][1][3] == 0.625
-    assert char["GenericOneQubitQErrors"][0][1][1][0] == 0.35
-    assert char["GenericOneQubitQErrors"][0][1][1][1] == 0.65
-    assert char["GenericOneQubitQErrors"][0][2][1][0] == 0.35
-    assert char["GenericOneQubitQErrors"][0][2][1][1] == 0.65
+    gqe2 = cast(Dict, char["GenericTwoQubitQErrors"])
+    gqe1 = cast(Dict, char["GenericOneQubitQErrors"])
+    assert gqe2[(0, 1)][0][1][0] == 0.0375
+    assert gqe2[(0, 1)][0][1][15] == 0.4375
+    assert gqe1[0][0][1][0] == 0.125
+    assert gqe1[0][0][1][3] == 0.625
+    assert gqe1[0][1][1][0] == 0.35
+    assert gqe1[0][1][1][1] == 0.65
+    assert gqe1[0][2][1][0] == 0.35
+    assert gqe1[0][2][1][1] == 0.65
     assert node_errors[arch.nodes[0]][OpType.U3] == 0.375
     assert link_errors[(arch.nodes[0], arch.nodes[1])][OpType.CX] == 0.5625
     assert link_errors[(arch.nodes[1], arch.nodes[0])][OpType.CX] == 0.80859375

--- a/modules/pytket-qiskit/tests/backend_test.py
+++ b/modules/pytket-qiskit/tests/backend_test.py
@@ -300,10 +300,8 @@ def test_process_characterisation_complete_noise_model() -> None:
     back = AerBackend(my_noise_model)
     char = cast(Dict[str, Any], back.characterisation)
 
-    # node_errors = cast(Dict[Node, dict], char.get("NodeErrors", {}))
-    # link_errors = cast(Dict[Tuple[Node, Node], dict], char.get("EdgeErrors", {}))
-    node_errors = back.backend_info.all_node_gate_errors
-    link_errors = back.backend_info.all_edge_gate_errors
+    node_errors = cast(Dict, back.backend_info.all_node_gate_errors)
+    link_errors = cast(Dict, back.backend_info.all_edge_gate_errors)
     arch = back.backend_info.architecture
 
     gqe2 = cast(Dict, char["GenericTwoQubitQErrors"])
@@ -319,11 +317,12 @@ def test_process_characterisation_complete_noise_model() -> None:
     assert node_errors[arch.nodes[0]][OpType.U3] == 0.375
     assert link_errors[(arch.nodes[0], arch.nodes[1])][OpType.CX] == 0.5625
     assert link_errors[(arch.nodes[1], arch.nodes[0])][OpType.CX] == 0.80859375
-    assert back.backend_info.all_readout_errors[arch.nodes[0]] == [
+    readout_errors = cast(Dict, back.backend_info.all_readout_errors)
+    assert readout_errors[arch.nodes[0]] == [
         [0.8, 0.2],
         [0.2, 0.8],
     ]
-    assert back.backend_info.all_readout_errors[arch.nodes[1]] == [
+    assert readout_errors[arch.nodes[1]] == [
         [0.7, 0.3],
         [0.3, 0.7],
     ]

--- a/modules/pytket-qiskit/tests/backend_test.py
+++ b/modules/pytket-qiskit/tests/backend_test.py
@@ -317,8 +317,14 @@ def test_process_characterisation_complete_noise_model() -> None:
     assert node_errors[arch.nodes[0]][OpType.U3] == 0.375
     assert link_errors[(arch.nodes[0], arch.nodes[1])][OpType.CX] == 0.5625
     assert link_errors[(arch.nodes[1], arch.nodes[0])][OpType.CX] == 0.80859375
-    assert back.backend_info.all_readout_errors[arch.nodes[0]] == [[0.8, 0.2], [0.2, 0.8]]
-    assert back.backend_info.all_readout_errors[arch.nodes[1]] == [[0.7, 0.3], [0.3, 0.7]]
+    assert back.backend_info.all_readout_errors[arch.nodes[0]] == [
+        [0.8, 0.2],
+        [0.2, 0.8],
+    ]
+    assert back.backend_info.all_readout_errors[arch.nodes[1]] == [
+        [0.7, 0.3],
+        [0.3, 0.7],
+    ]
 
 
 def test_cancellation_aer() -> None:

--- a/modules/pytket-qiskit/tests/backend_test.py
+++ b/modules/pytket-qiskit/tests/backend_test.py
@@ -15,13 +15,13 @@ import json
 import os
 import sys
 from collections import Counter
-from typing import Dict, Any, Tuple, cast
+from typing import Dict, Any, cast
 import math
 import cmath
 import pickle
 from hypothesis import given, strategies
 import numpy as np
-from pytket.circuit import Circuit, OpType, BasisOrder, Node, Qubit, reg_eq  # type: ignore
+from pytket.circuit import Circuit, OpType, BasisOrder, Qubit, reg_eq  # type: ignore
 from pytket.passes import CliffordSimp  # type: ignore
 from pytket.pauli import Pauli, QubitPauliString  # type: ignore
 from pytket.predicates import CompilationUnit, NoMidMeasurePredicate  # type: ignore

--- a/modules/pytket-qiskit/tests/backend_test.py
+++ b/modules/pytket-qiskit/tests/backend_test.py
@@ -300,8 +300,10 @@ def test_process_characterisation_complete_noise_model() -> None:
     back = AerBackend(my_noise_model)
     char = cast(Dict[str, Any], back.characterisation)
 
-    node_errors = cast(Dict[Node, dict], char.get("NodeErrors", {}))
-    link_errors = cast(Dict[Tuple[Node, Node], dict], char.get("EdgeErrors", {}))
+    # node_errors = cast(Dict[Node, dict], char.get("NodeErrors", {}))
+    # link_errors = cast(Dict[Tuple[Node, Node], dict], char.get("EdgeErrors", {}))
+    node_errors = back.backend_info.all_node_gate_errors
+    link_errors = back.backend_info.all_edge_gate_errors
     arch = back.backend_info.architecture
 
     assert char["GenericTwoQubitQErrors"][(0, 1)][0][1][0] == 0.0375
@@ -315,8 +317,8 @@ def test_process_characterisation_complete_noise_model() -> None:
     assert node_errors[arch.nodes[0]][OpType.U3] == 0.375
     assert link_errors[(arch.nodes[0], arch.nodes[1])][OpType.CX] == 0.5625
     assert link_errors[(arch.nodes[1], arch.nodes[0])][OpType.CX] == 0.80859375
-    assert char["ReadoutErrors"][arch.nodes[0]] == [[0.8, 0.2], [0.2, 0.8]]
-    assert char["ReadoutErrors"][arch.nodes[1]] == [[0.7, 0.3], [0.3, 0.7]]
+    assert back.backend_info.all_readout_errors[arch.nodes[0]] == [[0.8, 0.2], [0.2, 0.8]]
+    assert back.backend_info.all_readout_errors[arch.nodes[1]] == [[0.7, 0.3], [0.3, 0.7]]
 
 
 def test_cancellation_aer() -> None:

--- a/modules/pytket-qsharp/pytket/extensions/qsharp/backends/common.py
+++ b/modules/pytket-qsharp/pytket/extensions/qsharp/backends/common.py
@@ -60,7 +60,6 @@ from pytket.extensions.qsharp.qsharp_convert import tk_to_qsharp
 
 if TYPE_CHECKING:
     from qsharp.loader import QSharpCallable  # type: ignore
-    from pytket.device import Device  # type: ignore
 
 
 def _from_tk1(a: float, b: float, c: float) -> Circuit:

--- a/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
+++ b/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
@@ -15,7 +15,7 @@
 """Methods to allow tket circuits to be ran on the Qulacs simulator
 """
 
-from typing import TYPE_CHECKING, List, Optional, Sequence, Union, cast
+from typing import List, Optional, Sequence, Union, cast
 from logging import warning
 from uuid import uuid4
 import numpy as np

--- a/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
+++ b/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
@@ -65,10 +65,6 @@ except ImportError:
     _GPU_ENABLED = False
 
 
-if TYPE_CHECKING:
-    from pytket.device import Device  # type: ignore
-
-
 class QulacsBackend(Backend):
     """
     Backend for running simulations on the Qulacs simulator
@@ -119,7 +115,7 @@ class QulacsBackend(Backend):
         return (str,)
 
     @property
-    def backend_info(self) -> Optional["Device"]:
+    def backend_info(self) -> Optional["BackendInfo"]:
         return None
 
     @property


### PR DESCRIPTION
Or explicitly, update pytket-qiskit, pytket-braket and pytket-pyquil to use new BackednInfo attributes instead of the characterisation bucket dictionary.