### PR TITLE
Feature/qulacs does not use openfermion

### DIFF
--- a/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
+++ b/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
@@ -51,7 +51,7 @@ from pytket.predicates import (  # type: ignore
     DefaultRegisterPredicate,
     Predicate,
 )
-from pytket.circuit import Pauli, Qubit  # type: ignore
+from pytket.circuit import Pauli  # type: ignore
 from pytket.pauli import QubitPauliString  # type: ignore
 from pytket.routing import Architecture  # type: ignore
 from pytket.utils.operators import QubitPauliOperator

--- a/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
+++ b/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
@@ -232,11 +232,11 @@ class QulacsBackend(Backend):
             if qps != QubitPauliString():
                 for qubit, pauli in qps.to_dict().items():
                     if pauli == Pauli.X:
-                        _items.append('X')
+                        _items.append("X")
                     elif pauli == Pauli.Y:
-                        _items.append('Y')
+                        _items.append("Y")
                     elif pauli == Pauli.Z:
-                        _items.append('Z')
+                        _items.append("Z")
                     _items.append(str(qubit.index[0]))
 
             qulacs_qps = " ".join(_items)

--- a/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
+++ b/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
@@ -52,8 +52,8 @@ from pytket.predicates import (  # type: ignore
     DefaultRegisterPredicate,
     Predicate,
 )
-from pytket.circuit import Pauli, Qubit
-from pytket.pauli import QubitPauliString
+from pytket.circuit import Pauli, Qubit  # type: ignore
+from pytket.pauli import QubitPauliString  # type: ignore
 from pytket.routing import Architecture  # type: ignore
 from pytket.utils.operators import QubitPauliOperator
 from pytket.utils.outcomearray import OutcomeArray

--- a/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
+++ b/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
@@ -231,7 +231,6 @@ class QulacsBackend(Backend):
         for (qps, coeff) in operator._dict.items():
             _items = []
             if qps != QubitPauliString():
-                print(qps)
                 for qubit, pauli in qps.to_dict().items():
                     if pauli == Pauli.X:
                         _items.append('X')

--- a/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
+++ b/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
@@ -52,6 +52,8 @@ from pytket.predicates import (  # type: ignore
     DefaultRegisterPredicate,
     Predicate,
 )
+from pytket.circuit import Pauli, Qubit
+from pytket.pauli import QubitPauliString
 from pytket.routing import Architecture  # type: ignore
 from pytket.utils.operators import QubitPauliOperator
 from pytket.utils.outcomearray import OutcomeArray
@@ -224,9 +226,25 @@ class QulacsBackend(Backend):
     ) -> complex:
         if valid_check:
             self._check_all_circuits([state_circuit], nomeasure_warn=False)
-        observable = create_observable_from_openfermion_text(
-            str(operator.to_OpenFermion())
-        )
+
+        observable = Observable(state_circuit.n_qubits)
+        for (qps, coeff) in operator._dict.items():
+            _items = []
+            if qps != QubitPauliString():
+                print(qps)
+                for qubit, pauli in qps.to_dict().items():
+                    if pauli == Pauli.X:
+                        _items.append('X')
+                    elif pauli == Pauli.Y:
+                        _items.append('Y')
+                    elif pauli == Pauli.Z:
+                        _items.append('Z')
+                    _items.append(str(qubit.index[0]))
+
+            qulacs_qps = " ".join(_items)
+            qulacs_coeff = complex(coeff.evalf())
+            observable.add_operator(qulacs_coeff, qulacs_qps)
+
         expectation_value = self._expectation_value(state_circuit, observable)
         del observable
         return expectation_value.real

--- a/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
+++ b/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
@@ -20,7 +20,6 @@ from logging import warning
 from uuid import uuid4
 import numpy as np
 from qulacs import Observable, QuantumState  # type: ignore
-from qulacs.observable import create_observable_from_openfermion_text  # type: ignore
 from pytket.backends import (
     Backend,
     CircuitNotRunError,

--- a/modules/pytket-qulacs/tests/test-requirements.txt
+++ b/modules/pytket-qulacs/tests/test-requirements.txt
@@ -1,1 +1,1 @@
-openfermion==1.0.0
+openfermion~=1.0.0

--- a/modules/pytket-qulacs/tests/test-requirements.txt
+++ b/modules/pytket-qulacs/tests/test-requirements.txt
@@ -1,1 +1,3 @@
-git+git://github.com/quantumlib/OpenFermion@086073666d275de736861b41ed535a9fe75e63ac#egg=openfermion
+hypothesis==6.14.3
+pytest==6.2.4
+openfermion==1.0.0

--- a/modules/pytket-qulacs/tests/test-requirements.txt
+++ b/modules/pytket-qulacs/tests/test-requirements.txt
@@ -1,3 +1,1 @@
-hypothesis==6.14.3
-pytest==6.2.4
 openfermion==1.0.0


### PR DESCRIPTION
- get_operator_expectation_value does not use OpenFermion, hence OpenFermion no longer being a runtime dependency

- test-requirements specifies hypothesis, OpenFermion and pytest as development dependencies