### PR TITLE
Update AerBackend._process_model()

### DIFF
--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
@@ -725,7 +725,7 @@ def _process_model(noise_model: NoiseModel, gate_set: Set[OpType]) -> dict:
             coupling_map.append(qubits)
 
     # free qubits (ie qubits with no link errors) have full connectivity
-    free_qubits = set(node_errors) - link_errors_qubits
+    free_qubits = set(node_errors).union(set(readout_errors)) - link_errors_qubits
 
     for q in free_qubits:
         for lq in link_errors_qubits:

--- a/modules/pytket-qiskit/tests/backend_test.py
+++ b/modules/pytket-qiskit/tests/backend_test.py
@@ -53,7 +53,7 @@ from qiskit import IBMQ  # type: ignore
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.circuit import Parameter  # type: ignore
 from qiskit.providers.aer.noise.noise_model import NoiseModel  # type: ignore
-from qiskit.providers.aer.noise import ReadoutError # type: ignore
+from qiskit.providers.aer.noise import ReadoutError  # type: ignore
 from qiskit.providers.aer.noise.errors import depolarizing_error, pauli_error  # type: ignore
 import pytest
 

--- a/modules/pytket-qiskit/tests/backend_test.py
+++ b/modules/pytket-qiskit/tests/backend_test.py
@@ -352,8 +352,10 @@ def test_process_model() -> None:
     assert "characterisation" in b.backend_info.misc
     assert "GenericOneQubitQErrors" in b.backend_info.misc["characterisation"]
     assert "GenericTwoQubitQErrors" in b.backend_info.misc["characterisation"]
-    assert nodes[3] in b.backend_info.all_node_gate_errors
-    assert (nodes[7], nodes[8]) in b.backend_info.all_edge_gate_errors
+    node_gate_errors = cast(Dict, b.backend_info.all_node_gate_errors)
+    assert nodes[3] in node_gate_errors
+    edge_gate_errors = cast(Dict, b.backend_info.all_edge_gate_errors)
+    assert (nodes[7], nodes[8]) in edge_gate_errors
 
 
 def test_cancellation_aer() -> None:

--- a/modules/pytket-qiskit/tests/backend_test.py
+++ b/modules/pytket-qiskit/tests/backend_test.py
@@ -53,7 +53,7 @@ from qiskit import IBMQ  # type: ignore
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.circuit import Parameter  # type: ignore
 from qiskit.providers.aer.noise.noise_model import NoiseModel  # type: ignore
-from qiskit.providers.aer.noise import ReadoutError
+from qiskit.providers.aer.noise import ReadoutError # type: ignore
 from qiskit.providers.aer.noise.errors import depolarizing_error, pauli_error  # type: ignore
 import pytest
 


### PR DESCRIPTION
Architecture qubits are implied by set error channels in noise model.
Previously the _free_qubits parameter did not successfully capture all defined qubits in noise mode, now it does.
I also added a basic test for the _process_model method as there was none previously.