### PR TITLE
[pytket-qiskit] Use provider to check job status

### DIFF
--- a/modules/pytket-qiskit/docs/changelog.rst
+++ b/modules/pytket-qiskit/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 * Qiskit version updated to 0.28.
+* Use provider API client to check job status without retrieving job in IBMQBackend.
 
 0.15.1 (July 2021)
 ------------------


### PR DESCRIPTION
without retrieving job (which could be slow due to retrieving results with it)

relevant qiskit docs: https://qiskit.org/documentation/_modules/qiskit/providers/ibmq/job/ibmqjob.html#IBMQJob.status