### PR TITLE
[pytket-qsharp] Update to qsharp 0.18.

### DIFF
--- a/modules/pytket-qsharp/_metadata.py
+++ b/modules/pytket-qsharp/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.15.0"
+__extension_version__ = "0.15.1"
 __extension_name__ = "pytket-qsharp"

--- a/modules/pytket-qsharp/docs/changelog.rst
+++ b/modules/pytket-qsharp/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+0.15.1 (unreleased)
+-------------------
+
+* Updated qsharp version requirement to 0.18.
+
 0.15.0 (July 2021)
 ------------------
 

--- a/modules/pytket-qsharp/setup.py
+++ b/modules/pytket-qsharp/setup.py
@@ -38,7 +38,11 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 0.13.0", "qsharp ~= 0.17.2105"],
+    install_requires=[
+        "pytket ~= 0.13.0",
+        "qsharp ~= 0.18.2107",
+        "qsharp-core ~= 0.18.2107",
+    ],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Also require a corresponding version of `qsharp-core`, since `qsharp` seems not do so, which can cause errors on upgrade.