### PR TITLE
[pytket-projectq] Upgraded requirements to `projectq ~= 0.7.0`

### DIFF
--- a/modules/pytket-projectq/setup.py
+++ b/modules/pytket-projectq/setup.py
@@ -38,7 +38,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 0.13.0", "projectq ~= 0.6.1"],
+    install_requires=["pytket ~= 0.13.0", "projectq ~= 0.7.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Just hiked the requirements. I checked with [projectq's changelog](https://github.com/ProjectQ-Framework/ProjectQ/releases/tag/v0.7.0), it does not look like anything should have been broken (and the tests pass).