### PR TITLE
support new honeywell simulator options

### DIFF
--- a/modules/pytket-honeywell/_metadata.py
+++ b/modules/pytket-honeywell/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.13.0"
+__extension_version__ = "0.14.0"
 __extension_name__ = "pytket-honeywell"

--- a/modules/pytket-honeywell/docs/changelog.rst
+++ b/modules/pytket-honeywell/docs/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 ~~~~~~~~~
 
+0.14.0 (August 2021)
+------------------
+
+* Support new Honeywell simulator options in :py:class:`HoneywellBackend`:
+"simulator" for simulator type, and "noisy_simulation" to toggle simulations
+with and without error models.
+* Device name no longer optional on :py:class:`HoneywellBackend` construction.
+
 0.13.0 (July 2021)
 ------------------
 


### PR DESCRIPTION
Simulator type (state-vector or stabilizer) specified on backend
initialisation, to perhaps support compilation and predicate checking in
future.
Whether to run noisy simulation specified at process_circuit time via
kwarg.