### PR TITLE
Upgrade Cirq version to 0.12

### DIFF
--- a/modules/pytket-cirq/setup.py
+++ b/modules/pytket-cirq/setup.py
@@ -38,7 +38,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 0.14.0rc0", "cirq ~= 0.11.0"],
+    install_requires=["pytket ~= 0.14.0rc0", "cirq ~= 0.12.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Some interesting changes including 3D Circuit visualisation, separating their support for other hardware vendors into separate modules (cirq-aqt, cirq-pasqal etc) and extended noise channel support, but nothing that effects the backend.