### PR TITLE
Update URLs on `pytket` repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pip install -e .
 
 If you wish to write your own backend extension for `pytket`, we recommend
 looking at the example notebook
-[here](https://github.com/CQCL/pytket/blob/master/examples/creating_backends.ipynb)
+[here](https://github.com/CQCL/pytket/blob/main/examples/creating_backends.ipynb)
 which explains how to do so.
 
 If you would like to add it to this repo, please follow the existing code and

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/tket_backend.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/tket_backend.py
@@ -61,7 +61,7 @@ class TketBackend(QiskitBackend):
     :py:class:`qiskit.transpiler.passes.Unroller`. For examples, see the `user manual
     <https://cqcl.github.io/pytket/build/html/manual_backend .html#embedding-into-
     qiskit>`_ or the `Qiskit integration example <ht
-    tps://github.com/CQCL/pytket/blob/master/examples/qiskit_integration. ipynb>`_.
+    tps://github.com/CQCL/pytket/blob/main/examples/qiskit_integration. ipynb>`_.
     """
 
     def __init__(self, backend: Backend, comp_pass: Optional[BasePass] = None):


### PR DESCRIPTION
The old ones get redirected anyway, but we may as well have them correct.