### PR TITLE
[pytket-qiskit] Ensure `tk_command_to_qiskit` returns an `Instruction`.

### DIFF
--- a/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
@@ -481,7 +481,7 @@ def append_tk_command_to_qiskit(
             qargs=qargs,
         )
         qcirc.global_phase += -params[0] / 2 - params[2] / 2
-        return qcirc
+        return qcirc.to_instruction()
     # others are direct translations
     try:
         gatetype, phase = _known_gate_rev_phase[optype]

--- a/modules/pytket-qiskit/tests/qiskit_convert_test.py
+++ b/modules/pytket-qiskit/tests/qiskit_convert_test.py
@@ -364,7 +364,7 @@ def test_correction() -> None:
     )
     comp_pass = SequencePass([DecomposeBoxes(), RebaseTket()])
     comp_pass.apply(c)
-    qc = tk_to_qiskit(c)
+    tk_to_qiskit(c)
 
 
 def test_cnx() -> None:

--- a/modules/pytket-qiskit/tests/qiskit_convert_test.py
+++ b/modules/pytket-qiskit/tests/qiskit_convert_test.py
@@ -49,7 +49,7 @@ from pytket.extensions.qiskit.result_convert import (
     _gen_uids,
 )
 from sympy import Symbol  # type: ignore
-from pytket.passes import RebaseTket, DecomposeBoxes, FullPeepholeOptimise  # type: ignore
+from pytket.passes import RebaseTket, DecomposeBoxes, FullPeepholeOptimise, SequencePass  # type: ignore
 from pytket.utils.results import compare_statevectors
 
 skip_remote_tests: bool = (
@@ -339,6 +339,32 @@ def test_condition_errors() -> None:
     assert "OpenQASM conditions must be an entire register in order" in str(
         errorinfo.value
     )
+
+
+def test_correction() -> None:
+    checked_x = Circuit(2, 1)
+    checked_x.CX(0, 1)
+    checked_x.X(0)
+    checked_x.CX(0, 1)
+    checked_x.Measure(1, 0)
+    x_box = CircBox(checked_x)
+    c = Circuit()
+    target = Qubit("t", 0)
+    ancilla = Qubit("a", 0)
+    success = Bit("s", 0)
+    c.add_qubit(target)
+    c.add_qubit(ancilla)
+    c.add_bit(success)
+    c.add_circbox(x_box, args=[target, ancilla, success])
+    c.add_circbox(
+        x_box,
+        args=[target, ancilla, success],
+        condition_bits=[success],
+        condition_value=0,
+    )
+    comp_pass = SequencePass([DecomposeBoxes(), RebaseTket()])
+    comp_pass.apply(c)
+    qc = tk_to_qiskit(c)
 
 
 def test_cnx() -> None:


### PR DESCRIPTION
The test case is taken from the example notebook that was failing [here](https://github.com/CQCL/pytket/blob/aa994fd4ae0db771c32f4b73fb176683582f1c92/examples/python/conditional_gate_example.py#L98).