### PR TITLE
[pytket-qsharp] Use `actions/setup-dotnet` in workflows.

### DIFF
--- a/.github/workflows/build-test
+++ b/.github/workflows/build-test
@@ -52,7 +52,8 @@ for MODULE in $MODULES_TO_TEST; do
     # FIXME see
     # https://github.com/CQCL/pytket-extensions/issues/180 and 
     # https://github.com/microsoft/iqsharp/issues/512
-    if [[ "${MODULE}" != "pytket-qsharp" || "${PLAT}" != "Windows" ]]
+    PYVER=`python -c 'import sys; print(".".join(map(str, sys.version_info[:2])))'`
+    if [[ "${MODULE}" != "pytket-qsharp" || "${PLAT}" != "Windows" || "${PYVER}" == "3.7" ]]
     then
         echo "${MODULE}..."
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -46,15 +46,14 @@ jobs:
       run: |
         docker pull rigetti/quilc
         docker pull rigetti/qvm
-    - name: Install dotnet SDK and iqsharp
+    - name: Install dotnet SDK
       if: contains(env.MODULES_TO_TEST, 'pytket-qsharp')
-      run: |
-        curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-        sudo apt-add-repository https://packages.microsoft.com/ubuntu/20.04/prod
-        sudo apt-get update
-        sudo apt-get install dotnet-sdk-3.1
-        echo "~/.dotnet/tools" >> $GITHUB_PATH
-        dotnet tool install -g Microsoft.Quantum.IQSharp
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+    - name: Install iqsharp
+      if: contains(env.MODULES_TO_TEST, 'pytket-qsharp')
+      run: dotnet tool install -g Microsoft.Quantum.IQSharp
 
     - name: Set up Python 3.7
       if: github.event_name == 'push'
@@ -116,13 +115,15 @@ jobs:
         MM=`python3 .github/workflows/changed_modules.py origin/${{ github.base_ref }} ${{ github.sha }}`
         echo "MODULES_TO_TEST=${MM}" >> $GITHUB_ENV
 
-    - name: Install dotnet SDK and iqsharp
+    - name: Install dotnet SDK
+      if: contains(env.MODULES_TO_TEST, 'pytket-qsharp')
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+    - name: Install iqsharp
       if: contains(env.MODULES_TO_TEST, 'pytket-qsharp')
       run: |
         brew install mono-libgdiplus jupyter
-        wget https://dot.net/v1/dotnet-install.sh
-        chmod a+x dotnet-install.sh
-        ./dotnet-install.sh --channel 3.1
         dotnet tool install -g Microsoft.Quantum.IQSharp
         dotnet iqsharp install
 
@@ -181,12 +182,14 @@ jobs:
         MM=`python .github/workflows/changed_modules.py origin/${{ github.base_ref }} ${{ github.sha }}`
         echo "MODULES_TO_TEST=${MM}" >> $GITHUB_ENV
 
-    - name: Install dotnet SDK and iqsharp
+    - name: Install dotnet SDK
       if: contains(env.MODULES_TO_TEST, 'pytket-qsharp')
-      run: |
-        Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -outfile "dotnet-install.ps1"
-        .\dotnet-install.ps1
-        dotnet tool install -g Microsoft.Quantum.IQSharp
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+    - name: Install iqsharp
+      if: contains(env.MODULES_TO_TEST, 'pytket-qsharp')
+      run: dotnet tool install -g Microsoft.Quantum.IQSharp
 
     - name: Set up Python 3.7
       if: github.event_name == 'push'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,13 +44,14 @@ jobs:
           pip install .
           cd ../..
         done
-    - name: Install dotnet SDK and iqsharp
+    - name: Install dotnet SDK
+      if: contains(env.MODULES_TO_TEST, 'pytket-qsharp')
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+    - name: Install iqsharp
+      if: contains(env.MODULES_TO_TEST, 'pytket-qsharp')
       run: |
-        curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-        sudo apt-add-repository https://packages.microsoft.com/ubuntu/20.04/prod
-        sudo apt-get update
-        sudo apt-get install dotnet-sdk-3.1
-        echo "~/.dotnet/tools" >> $GITHUB_PATH
         dotnet tool install -g Microsoft.Quantum.IQSharp
         dotnet iqsharp install --user
     - name: Install docs dependencies

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -42,15 +42,14 @@ jobs:
       run: |
         docker pull rigetti/quilc
         docker pull rigetti/qvm
-    - name: Install dotnet SDK and iqsharp
+    - name: Install dotnet SDK
       if: contains(env.MODULES_TO_TEST, 'pytket-qsharp')
-      run: |
-        curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-        sudo apt-add-repository https://packages.microsoft.com/ubuntu/20.04/prod
-        sudo apt-get update
-        sudo apt-get install dotnet-sdk-3.1
-        echo "~/.dotnet/tools" >> $GITHUB_PATH
-        dotnet tool install -g Microsoft.Quantum.IQSharp
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+    - name: Install iqsharp
+      if: contains(env.MODULES_TO_TEST, 'pytket-qsharp')
+      run: dotnet tool install -g Microsoft.Quantum.IQSharp
 
     - name: Set up Python 3.9
       uses: actions/setup-python@v2


### PR DESCRIPTION
Also enable testing of pytket-qsharp on Python 3.7, since that is the one configuration not affected by #180 .
Closes #188 .
Tested: https://github.com/CQCL/pytket-extensions/actions/runs/1290980057 and https://github.com/CQCL/pytket-extensions/actions/runs/1291025849