### PR TITLE
[pytket-qulacs] Relax openfermion requirement for pytket-qulacs tests.

### DIFF
--- a/modules/pytket-qulacs/tests/test-requirements.txt
+++ b/modules/pytket-qulacs/tests/test-requirements.txt
@@ -1,2 +1,2 @@
 -r ../../base-test-requirements.txt
-openfermion~=1.1.0
+openfermion~=1.1


### PR DESCRIPTION
Allows use of 1.2 which is the current latest version.