### PR TITLE
[feature][pytket-honeywell] Add option to store credentials in memory.

### DIFF
--- a/modules/base-test-requirements.txt
+++ b/modules/base-test-requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-timeout ~= 1.4.2
 hypothesis
+requests_mock

--- a/modules/pytket-honeywell/pytket/extensions/honeywell/__init__.py
+++ b/modules/pytket-honeywell/pytket/extensions/honeywell/__init__.py
@@ -18,4 +18,4 @@
 # _metadata.py is copied to the folder after installation.
 from ._metadata import __extension_version__, __extension_name__  # type: ignore
 from .backends import HoneywellBackend
-from .backends.api_wrappers import split_utf8
+from .backends.credential_storage import split_utf8

--- a/modules/pytket-honeywell/pytket/extensions/honeywell/backends/__init__.py
+++ b/modules/pytket-honeywell/pytket/extensions/honeywell/backends/__init__.py
@@ -16,4 +16,4 @@
 """
 
 from .honeywell import HoneywellBackend
-from .api_wrappers import split_utf8
+from .credential_storage import split_utf8

--- a/modules/pytket-honeywell/pytket/extensions/honeywell/backends/api_wrappers.py
+++ b/modules/pytket-honeywell/pytket/extensions/honeywell/backends/api_wrappers.py
@@ -8,8 +8,7 @@ Adapted from original file provided by Honeywell Quantum Solutions
 import datetime
 import time
 from http import HTTPStatus
-from typing import Iterable, Optional, Dict, Any, Tuple
-from itertools import takewhile, count
+from typing import Optional, Dict, Any, Tuple
 import asyncio
 import json
 import getpass
@@ -17,9 +16,9 @@ import jwt
 import requests
 from websockets import connect, exceptions  # type: ignore
 import nest_asyncio  # type: ignore
-import keyring  # type: ignore
 
 from .config import HoneywellConfig
+from .credential_storage import CredentialStorage, MemoryStorage, PersistentStorage
 
 # This is necessary for use in Jupyter notebooks to allow for nested asyncio loops
 nest_asyncio.apply()
@@ -27,20 +26,6 @@ nest_asyncio.apply()
 
 class HQSAPIError(Exception):
     pass
-
-
-def split_utf8(s: str, n: int) -> Iterable[str]:
-    # stolen from
-    # https://stackoverflow.com/questions/6043463/split-unicode-string-into-300-byte-chunks-without-destroying-characters
-    """Split UTF-8 s into chunks of maximum length n."""
-    s_bytes = s.encode("utf-8")
-    while len(s_bytes) > n:
-        k = n
-        while (s_bytes[k] & 0xC0) == 0x80:
-            k -= 1
-        yield s_bytes[:k].decode("utf-8")
-        s_bytes = s_bytes[k:]
-    yield s_bytes.decode("utf-8")
 
 
 class _OverrideManager:
@@ -76,8 +61,6 @@ class HoneywellQAPI:
         60  # Default safety factor (in seconds) to token expiration before a refresh
     )
 
-    KEYRING_NAME = "HQS-API"
-
     def __init__(
         self,
         user_name: Optional[str] = None,
@@ -88,6 +71,8 @@ class HoneywellQAPI:
         use_websocket: bool = True,
         time_safety: Optional[int] = None,
         login: bool = True,
+        persistent_credential: bool = True,
+        __pwd: Optional[str] = None,
     ):
         """Initialize and login to the Honeywell Quantum API interface
 
@@ -96,10 +81,18 @@ class HoneywellQAPI:
         Arguments:
             user_name (str): User e-mail used to register
             token (str): Token used to refresh id token
-            url (str): Url of the Quantum API including version:
-             https://qapi.honeywell.com/v1/
-            shots (int): Default number of shots for submitted experiments
-            use_websockets: Whether to default to using websockets to reduce traffic
+            api_url (str): Url of the Quantum API:
+             https://qapi.honeywell.com/
+            api_version (str): API version
+            use_websocket (bool): Whether to default to using websockets
+            to reduce traffic
+            time_safety (int): seconds before token expiration within which
+            to refresh tokens
+            login (bool): attempt to login during initialiasation
+            persistent_credential (bool): use keyring to store credentials
+            (instead of memory)
+            __pwd (str): password for the service. For debugging purposes only,
+            do not store password in source code.
         """
         self.config = HoneywellConfig.from_default_config_file()
 
@@ -108,10 +101,17 @@ class HoneywellQAPI:
             if api_url
             else f"{self.DEFAULT_API_URL}v{api_version}/"
         )
-        self.keyring_service = self.KEYRING_NAME
-
+        self._cred_store: CredentialStorage = (
+            MemoryStorage() if not persistent_credential else PersistentStorage()
+        )
         self.user_name = user_name if user_name else self.config.username
-        self.refresh_token = token if token else self._get_token("refresh_token")
+        if self.user_name is not None and __pwd is not None:
+            self._cred_store.save_login_credential(self.user_name, __pwd)
+
+        refresh_token = token if token else self._cred_store.refresh_token
+        if refresh_token is not None:
+            self._cred_store.save_refresh_token(refresh_token)
+
         self.api_version = api_version
         self.machine = machine
         self.use_websocket = use_websocket
@@ -147,7 +147,7 @@ class HoneywellQAPI:
 
             else:
                 print("***Successfully logged in***")
-                self._save_tokens(
+                self._cred_store.save_tokens(
                     response.json()["id-token"], response.json()["refresh-token"]
                 )
                 return response.status_code, None
@@ -159,10 +159,7 @@ class HoneywellQAPI:
     def _get_credentials(self) -> Tuple[str, str]:
         """Method to ask for user's credentials"""
         if self.config.username is not None:
-            pwd = keyring.get_password(  # type: ignore
-                self.keyring_service,
-                self.config.username,
-            )
+            pwd = self._cred_store.login_credential(self.config.username)  # type: ignore
             if pwd:
                 self.user_name = self.config.username
                 return self.user_name, pwd
@@ -171,7 +168,10 @@ class HoneywellQAPI:
             user_name = input("Enter your email: ")
             self.user_name = user_name
 
-        pwd = getpass.getpass(prompt="Enter your password: ")
+        pwd = self._cred_store.login_credential(self.user_name)
+        if not pwd:
+            pwd = getpass.getpass(prompt="Enter your password: ")
+            self._cred_store.save_login_credential(self.user_name, pwd)
         return self.user_name, pwd
 
     def _authenticate(
@@ -191,7 +191,7 @@ class HoneywellQAPI:
         body = {}
 
         if action == "refresh":
-            body["refresh-token"] = self.refresh_token
+            body["refresh-token"] = self._cred_store.refresh_token
         else:
             # ask user for crendentials before making login request
             user_name: Optional[str]
@@ -234,52 +234,19 @@ class HoneywellQAPI:
                 f"{status_code} {'' if message is None else message}"
             )
 
-    def _get_token_parts(self, token_name: str) -> Iterable[str]:
-        token_parts = (
-            keyring.get_password(self.keyring_service, f"{token_name}_{i}")  # type: ignore
-            for i in count(start=0)
-        )
-        return takewhile(lambda x: x is not None, token_parts)  # type: ignore
-
-    def _get_token(self, token_name: str):  # type: ignore
-        """Method to retrieve id and refresh tokens from system's keyring service.
-        Windows keyring backend has a length limitation on passwords.
-        To avoid this, passwords get split in to tokens of length 512.
-        """
-
-        token = "".join(self._get_token_parts(token_name))
-        return token if token else None
-
-    def _save_tokens(self, id_token: str, refresh_token: str) -> None:
-        """Method to save id and refresh tokens on system's keyring service.
-        Windows keyring backend has a length limitation on passwords.
-        To avoid this, passwords get split in to tokens of length 512.
-        """
-
-        split_id_tokens = list(split_utf8(id_token, 512))
-        split_refresh_tokens = list(split_utf8(refresh_token, 512))
-
-        for token_list, token_name in zip(
-            (split_id_tokens, split_refresh_tokens), ("id_token", "refresh_token")
-        ):
-            for index, part in enumerate(token_list):
-                keyring.set_password(  # type: ignore
-                    self.keyring_service, f"{token_name}_{index}", part
-                )
-
     def login(self) -> str:
         """This methods checks if we have a valid (non-expired) id-token
         and returns it, otherwise it gets a new one with refresh-token.
         If refresh-token doesn't exist, it asks user for credentials.
         """
         # check if id_token exists
-        id_token = self._get_token("id_token")
+        id_token = self._cred_store.id_token
         if id_token is None:
             # authenticate against '/login' endpoint
             self._authenticate()
 
             # get id_token
-            id_token = self._get_token("id_token")
+            id_token = self._cred_store.id_token
         if id_token is None:
             raise HQSAPIError("Unable to retrieve id token.")
         # check id_token is not expired yet
@@ -290,27 +257,22 @@ class HoneywellQAPI:
             print("Your id token is expired. Refreshing...")
 
             # get refresh_token
-            refresh_token = self._get_token("refresh_token")
+            refresh_token = self._cred_store.refresh_token
             if refresh_token is not None:
                 self._authenticate("refresh")
             else:
                 self._authenticate()
 
             # get id_token
-            id_token = self._get_token("id_token")
+            id_token = self._cred_store.id_token
 
         return id_token  # type: ignore
 
     def delete_authentication(self) -> None:
-        """Use keyrings delete_password to remove stored"""
-        for token_name in ("id_token", "refresh_token"):
-            for index in count():
-                token_part = f"{token_name}_{index}"
-                try:
-                    keyring.delete_password(self.keyring_service, token_part)  # type: ignore
-                except keyring.errors.PasswordDeleteError:
-                    # stop when the token part doesn't exist
-                    break
+        """Remove stored credentials and tokens"""
+        if self.user_name:
+            self._cred_store.delete_login_credential(self.user_name)
+        self._cred_store.delete_tokens()
 
     def recent_jobs(
         self,

--- a/modules/pytket-honeywell/pytket/extensions/honeywell/backends/api_wrappers.py
+++ b/modules/pytket-honeywell/pytket/extensions/honeywell/backends/api_wrappers.py
@@ -135,7 +135,7 @@ class HoneywellQAPI:
         try:
             # send request to login
             response = requests.post(
-                f"{self.url}/login",
+                f"{self.url}login",
                 json.dumps(body),
             )
 

--- a/modules/pytket-honeywell/pytket/extensions/honeywell/backends/api_wrappers.py
+++ b/modules/pytket-honeywell/pytket/extensions/honeywell/backends/api_wrappers.py
@@ -43,7 +43,7 @@ def split_utf8(s: str, n: int) -> Iterable[str]:
     yield s_bytes.decode("utf-8")
 
 
-class _OverrideManger:
+class _OverrideManager:
     def __init__(
         self,
         api_handler: "HoneywellQAPI",
@@ -120,15 +120,15 @@ class HoneywellQAPI:
         )
         self.ws_timeout = 180
         self.retry_timeout = 5
-        self.timeout: Optional[int] = None  # don't timetout by default
+        self.timeout: Optional[int] = None  # don't timeout by default
 
         if login:
             self.login()
 
     def override_timeouts(
         self, timeout: Optional[int] = None, retry_timeout: Optional[int] = None
-    ) -> _OverrideManger:
-        return _OverrideManger(self, timeout=timeout, retry_timeout=retry_timeout)
+    ) -> _OverrideManager:
+        return _OverrideManager(self, timeout=timeout, retry_timeout=retry_timeout)
 
     def _request_tokens(self, body: dict) -> Tuple[Optional[int], Optional[Any]]:
         """Method to send login request to machine api and save tokens."""

--- a/modules/pytket-honeywell/pytket/extensions/honeywell/backends/credential_storage.py
+++ b/modules/pytket-honeywell/pytket/extensions/honeywell/backends/credential_storage.py
@@ -1,0 +1,183 @@
+""""
+Classes used to handle saving and retrieving credentials
+"""
+
+from typing import Iterable, Optional
+from abc import ABC, abstractmethod
+from itertools import takewhile, count
+import keyring
+
+
+def split_utf8(s: str, n: int) -> Iterable[str]:
+    # stolen from
+    # https://stackoverflow.com/questions/6043463/split-unicode-string-into-300-byte-chunks-without-destroying-characters
+    """Split UTF-8 s into chunks of maximum length n."""
+    s_bytes = s.encode("utf-8")
+    while len(s_bytes) > n:
+        k = n
+        while (s_bytes[k] & 0xC0) == 0x80:
+            k -= 1
+        yield s_bytes[:k].decode("utf-8")
+        s_bytes = s_bytes[k:]
+    yield s_bytes.decode("utf-8")
+
+
+class CredentialStorage(ABC):
+    """Abstract class for managing credentials and tokens for the Honeywell API."""
+
+    @abstractmethod
+    def save_login_credential(self, user_name: str, password: str) -> None:
+        """Save the user_name and password"""
+        ...
+
+    @abstractmethod
+    def login_credential(self, user_name: str) -> Optional[str]:
+        """Retrieve the password associated with the user_name"""
+        ...
+
+    @abstractmethod
+    def save_tokens(self, id_token: str, refresh_token: str) -> None:
+        """Save the id_token and refresh_token"""
+        ...
+
+    @abstractmethod
+    def save_refresh_token(self, refresh_token: str) -> None:
+        """Save the refresh_token"""
+        ...
+
+    @property
+    @abstractmethod
+    def id_token(self) -> Optional[str]:
+        """Retrieve the id_token"""
+        ...
+
+    @property
+    @abstractmethod
+    def refresh_token(self) -> Optional[str]:
+        """Retrieve the refresh_token"""
+        ...
+
+    @abstractmethod
+    def delete_login_credential(self, user_name: str) -> None:
+        """Delete the stored username and password"""
+        ...
+
+    @abstractmethod
+    def delete_tokens(self) -> None:
+        """Delete the refresh_token and id_token"""
+        ...
+
+
+class MemoryStorage(CredentialStorage):
+
+    """In memory credential storage"""
+
+    def __init__(self) -> None:
+        self._user_name: Optional[str] = None
+        self._password: Optional[str] = None
+        self._id_token: Optional[str] = None
+        self._refresh_token: Optional[str] = None
+
+    def save_login_credential(self, user_name: str, password: str) -> None:
+        self._user_name = user_name
+        self._password = password
+
+    def login_credential(self, user_name: str) -> Optional[str]:
+        self._user_name = user_name
+        return None if self._password is None else self._password
+
+    def save_tokens(self, id_token: str, refresh_token: str) -> None:
+        self._id_token = id_token
+        self._refresh_token = refresh_token
+
+    def save_refresh_token(self, refresh_token: str) -> None:
+        self._refresh_token = refresh_token
+
+    @property
+    def id_token(self) -> Optional[str]:
+        return self._id_token
+
+    @property
+    def refresh_token(self) -> Optional[str]:
+        return self._refresh_token
+
+    def delete_login_credential(self, user_name: str) -> None:
+        self._user_name = None
+        self._password = None
+
+    def delete_tokens(self) -> None:
+        self._id_token = None
+        self._refresh_token = None
+
+
+class PersistentStorage(CredentialStorage):
+
+    """Persistent credential storage using keyring"""
+
+    KEYRING_SERVICE = "HQS-API"
+
+    def save_login_credential(self, user_name: str, password: str) -> None:
+        keyring.set_password(self.KEYRING_SERVICE, user_name, password)
+
+    def login_credential(self, user_name: str) -> Optional[str]:
+        password = keyring.get_password(self.KEYRING_SERVICE, user_name)
+        return None if password is None else password
+
+    def save_tokens(self, id_token: str, refresh_token: str) -> None:
+        """Method to save id and refresh tokens on system's keyring service.
+        Windows keyring backend has a length limitation on passwords.
+        To avoid this, passwords get split in to tokens of length 512.
+        """
+
+        split_id_tokens = list(split_utf8(id_token, 512))
+        split_refresh_tokens = list(split_utf8(refresh_token, 512))
+
+        for token_list, token_name in zip(
+            (split_id_tokens, split_refresh_tokens), ("id_token", "refresh_token")
+        ):
+            for index, part in enumerate(token_list):
+                keyring.set_password(  # type: ignore
+                    self.KEYRING_SERVICE, f"{token_name}_{index}", part
+                )
+
+    def save_refresh_token(self, refresh_token: str) -> None:
+        split_refresh_tokens = list(split_utf8(refresh_token, 512))
+
+        for index, token_part in enumerate(split_refresh_tokens):
+            keyring.set_password(  # type: ignore
+                self.KEYRING_SERVICE, f"refresh_token_{index}", token_part
+            )
+
+    @property
+    def id_token(self) -> Optional[str]:
+        token = "".join(self._get_token_parts("id_token"))
+        return token if token else None
+
+    @property
+    def refresh_token(self) -> Optional[str]:
+        token = "".join(self._get_token_parts("refresh_token"))
+        return token if token else None
+
+    def delete_login_credential(self, user_name: str) -> None:
+        try:
+            keyring.delete_password(self.KEYRING_SERVICE, user_name)
+        except keyring.errors.PasswordDeleteError:
+            pass
+
+    def delete_tokens(self) -> None:
+        """Delete tokens in the keyring"""
+        for token_name in ("id_token", "refresh_token"):
+            for index in count():
+                token_part = f"{token_name}_{index}"
+                try:
+                    keyring.delete_password(self.KEYRING_SERVICE, token_part)
+                except keyring.errors.PasswordDeleteError:
+                    # stop when the token part doesn't exist
+                    break
+
+    def _get_token_parts(self, token_name: str) -> Iterable[str]:
+        token_parts = (
+            keyring.get_password(self.KEYRING_SERVICE, f"{token_name}_{i}")  # type: ignore
+            for i in count(start=0)
+        )
+        return takewhile(lambda x: x is not None, token_parts)  # type: ignore

--- a/modules/pytket-honeywell/pytket/extensions/honeywell/backends/credential_storage.py
+++ b/modules/pytket-honeywell/pytket/extensions/honeywell/backends/credential_storage.py
@@ -1,6 +1,16 @@
-""""
-Classes used to handle saving and retrieving credentials
-"""
+# Copyright 2020-2021 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from typing import Iterable, Optional
 from abc import ABC, abstractmethod

--- a/modules/pytket-honeywell/tests/api_test.py
+++ b/modules/pytket-honeywell/tests/api_test.py
@@ -50,7 +50,6 @@ def test_machine_status(
     machine_name = "HQS-LT-S1-APIVAL"
     mock_machine_state = "online"
 
-    # Mock /login endpoint
     mock_url = f"https://qapi.honeywell.com/v1/machine/{machine_name}"
 
     requests_mock.register_uri(

--- a/modules/pytket-honeywell/tests/api_test.py
+++ b/modules/pytket-honeywell/tests/api_test.py
@@ -1,0 +1,109 @@
+# Copyright 2020-2021 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import sys
+
+import pytest
+from requests_mock.mocker import Mocker
+import jwt
+
+from pytket.extensions.honeywell.backends.api_wrappers import HoneywellQAPI
+from pytket.extensions.honeywell.backends.credential_storage import (
+    CredentialStorage,
+    MemoryStorage,
+    PersistentStorage,
+)
+
+
+@pytest.mark.parametrize("test_keyring_storage", [True, False])
+def test_hqs_login(test_keyring_storage: bool, requests_mock: Mocker) -> None:
+    """Test that credentials are storable and deletable using
+    the HoneywellQAPI handler."""
+
+    username = "mark.honeywell@mail.com"
+    pwd = "1906"
+
+    id_payload = {"exp": (datetime.datetime.now().timestamp() * 2)}
+
+    mock_id_token = jwt.encode(id_payload, key="").decode("utf-8")
+
+    # Mock /login endpoint
+    mock_url = "https://qapi.honeywell.com/v1/login"
+
+    requests_mock.register_uri(
+        "POST",
+        mock_url,
+        json={
+            "id-token": mock_id_token,
+            "refresh-token": mock_id_token,
+        },
+        headers={"Content-Type": "application/json"},
+    )
+
+    cred_store: CredentialStorage
+    # Skip testing keyring service if running on linux
+    if test_keyring_storage and sys.platform != "linux":
+        cred_store = PersistentStorage()
+        cred_store.KEYRING_SERVICE = "HQS_API_MOCK"
+    else:
+        cred_store = MemoryStorage()
+
+    cred_store.save_login_credential(
+        user_name=username,
+        password=pwd,
+    )
+
+    api_handler = HoneywellQAPI(
+        user_name=username,
+        token="",
+        persistent_credential=False,
+        login=False,
+    )
+
+    api_handler._cred_store = cred_store
+    api_handler.login()
+
+    # Check credentials are retrievable
+    assert api_handler._cred_store.login_credential(username) == pwd
+    assert api_handler._cred_store.refresh_token == mock_id_token
+    assert api_handler._cred_store.id_token == mock_id_token
+
+    # Delete authentication and verify
+    api_handler.delete_authentication()
+    assert api_handler._cred_store.id_token == None
+    assert api_handler._cred_store.login_credential(username) == None
+    assert api_handler._cred_store.refresh_token == None
+
+
+def test_machine_status(
+    requests_mock: Mocker,
+    mock_hqs_api_handler: HoneywellQAPI,
+) -> None:
+    """Test that we can retrieve the machine state via  Honeywell endpoint."""
+
+    machine_name = "HQS-LT-S1-APIVAL"
+    mock_machine_state = "online"
+
+    # Mock /login endpoint
+    mock_url = f"https://qapi.honeywell.com/v1/machine/{machine_name}"
+
+    requests_mock.register_uri(
+        "GET",
+        mock_url,
+        json={"state": mock_machine_state},
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert mock_hqs_api_handler.status(machine_name) == mock_machine_state

--- a/modules/pytket-honeywell/tests/backend_test.py
+++ b/modules/pytket-honeywell/tests/backend_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from collections import Counter
 from typing import cast, Callable, Any  # pylint: disable=unused-import
 from ast import literal_eval
@@ -342,15 +343,3 @@ def test_retrieve_available_devices() -> None:
     api_handler = HoneywellQAPI()
     backend_infos = HoneywellBackend.available_devices(api_handler=api_handler)
     assert len(backend_infos) > 0
-
-
-# hard to run as it involves removing credentials
-# def test_delete_authentication():
-#     print("first login")
-#     b = HoneywellBackend()
-#     print("delete login")
-
-#     b.delete_authentication()
-#     print("second login")
-
-#     b = HoneywellBackend()

--- a/modules/pytket-honeywell/tests/conftest.py
+++ b/modules/pytket-honeywell/tests/conftest.py
@@ -54,7 +54,6 @@ def fixture_mock_hqs_api_handler(
 
     username, pwd = mock_credentials
 
-    # Mock /login endpoint
     mock_url = "https://qapi.honeywell.com/v1/login"
 
     requests_mock.register_uri(

--- a/modules/pytket-honeywell/tests/conftest.py
+++ b/modules/pytket-honeywell/tests/conftest.py
@@ -1,0 +1,60 @@
+# Copyright 2020-2021 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+
+import pytest
+from requests_mock.mocker import Mocker
+import jwt
+
+from pytket.extensions.honeywell.backends.api_wrappers import HoneywellQAPI
+
+# pylint: disable=R0801
+@pytest.fixture(name="mock_hqs_api_handler")
+def fixture_mock_hqs_api_handler(
+    requests_mock: Mocker,
+) -> HoneywellQAPI:
+    """A logged-in HoneywellQAPI fixture."""
+
+    username = "mark.honeywell@mail.com"
+    pwd = "1906"
+
+    id_payload = {"exp": (datetime.datetime.now().timestamp() * 2)}
+
+    mock_id_token = jwt.encode(id_payload, key="").decode("utf-8")
+
+    # Mock /login endpoint (_request_tokens)
+    mock_url = "https://qapi.honeywell.com/v1/login"
+
+    requests_mock.register_uri(
+        "POST",
+        mock_url,
+        json={
+            "id-token": mock_id_token,
+            "refresh-token": mock_id_token,
+        },
+        headers={"Content-Type": "application/json"},
+    )
+
+    # Construct HoneywellQAPI and login
+    # pylint: disable=E1123
+    api_handler = HoneywellQAPI(
+        user_name=username,
+        token="",
+        persistent_credential=False,
+        login=True,
+        _HoneywellQAPI__pwd=pwd,  # type: ignore
+    )
+
+    return api_handler

--- a/modules/pytket-honeywell/tests/conftest.py
+++ b/modules/pytket-honeywell/tests/conftest.py
@@ -50,7 +50,11 @@ def fixture_mock_hqs_api_handler(
     mock_credentials: Tuple[str, str],
     mock_token: str,
 ) -> HoneywellQAPI:
-    """A logged-in HoneywellQAPI fixture."""
+    """A logged-in HoneywellQAPI fixture.
+    After using this fixture in a test, call:
+        mock_hqs_api_handler.delete_authentication()
+    To remove mock tokens from the keyring.
+    """
 
     username, pwd = mock_credentials
 
@@ -80,13 +84,13 @@ def fixture_mock_hqs_api_handler(
     )
 
     # Construct HoneywellQAPI and login
-    # pylint: disable=E1123
     api_handler = HoneywellQAPI(
-        user_name=username,
-        token="",
+        persistent_credential=False,
         login=False,
     )
 
+    # Add the credential storage seperately in line with fixture parameters
+    api_handler.user_name = username
     api_handler._cred_store = cred_store
     api_handler.login()
 

--- a/modules/pytket-qiskit/docs/changelog.rst
+++ b/modules/pytket-qiskit/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+0.21.0 (unreleased)
+-------------------
+
+* Qiskit version updated to 0.33.
+
 0.20.0 (November 2021)
 ----------------------
 

--- a/modules/pytket-qiskit/setup.py
+++ b/modules/pytket-qiskit/setup.py
@@ -38,7 +38,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 0.17.0", "qiskit ~= 0.32.0"],
+    install_requires=["pytket ~= 0.17.0", "qiskit ~= 0.33.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.7",

--- a/modules/pytket-qiskit/tests/qiskit_backend_test.py
+++ b/modules/pytket-qiskit/tests/qiskit_backend_test.py
@@ -103,9 +103,9 @@ def test_cancel() -> None:
     b = AerBackend()
     tb = TketBackend(b)
     qc = circuit_gen()
-    job = execute(qc, tb)
+    job = execute(qc, tb, shots=1024)
     job.cancel()
-    assert job.status() == JobStatus.CANCELLED
+    assert job.status() in [JobStatus.CANCELLED, JobStatus.DONE]
 
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)

--- a/modules/pytket-qiskit/tests/qiskit_convert_test.py
+++ b/modules/pytket-qiskit/tests/qiskit_convert_test.py
@@ -271,7 +271,7 @@ def test_tketautopass() -> None:
 def test_instruction() -> None:
     # TKET-446
     qreg = QuantumRegister(3)
-    op = PauliSumOp.from_list([("XXI", 0.3), ("YYI", 0.5 + 1j * 0.2), ("ZZZ", -0.4)])
+    op = PauliSumOp.from_list([("XXI", 0.3), ("YYI", 0.5), ("ZZZ", -0.4)])
     evolved_op = (1.2 * op).exp_i()
     evo = PauliTrotterEvolution(reps=1)
     evo_circop = evo.convert(evolved_op)


### PR DESCRIPTION
This PR enables the `HoneywellQAPI` api wrapper to optionally store credentials (password, id_token and refresh_token) in memory as opposed to in persistent storage via `keyring`. Persistent storage is used by default.

I've done reasonably thorough manual testing, but haven't added any `pytest` tests as testing credential-related features doesn't appear to be standard across the pytket-extensions. Very happy to make any desired changes.