### PR TITLE
Use `FullyConnected` connectivity graph.

### DIFF
--- a/modules/pytket-aqt/setup.py
+++ b/modules/pytket-aqt/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 0.17.0", "requests ~= 2.22", "types-requests"],
+    install_requires=["pytket ~= 0.18.0rc0", "requests ~= 2.22", "types-requests"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.7",

--- a/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
+++ b/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
@@ -66,7 +66,7 @@ from pytket.predicates import (  # type: ignore
     NoSymbolsPredicate,
     Predicate,
 )
-from pytket.routing import Architecture, FullyConnected, NoiseAwarePlacement  # type: ignore
+from pytket.routing import Architecture, NoiseAwarePlacement  # type: ignore
 from pytket.utils import prepare_circuit
 from pytket.utils.operators import QubitPauliOperator
 from pytket.utils.outcomearray import OutcomeArray
@@ -419,11 +419,10 @@ class BraketBackend(Backend):
             all_qubits = list(range(n_qubits))
 
         if connectivity_graph is None:
-            arch = FullyConnected(n_qubits)
-        else:
-            arch = Architecture(
-                [(k, v) for k, l in connectivity_graph.items() for v in l]
+            connectivity_graph = dict(
+                (k, [v for v in range(n_qubits) if v != k]) for k in range(n_qubits)
             )
+        arch = Architecture([(k, v) for k, l in connectivity_graph.items() for v in l])
         return arch, all_qubits
 
     @classmethod

--- a/modules/pytket-braket/setup.py
+++ b/modules/pytket-braket/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 0.17.0", "amazon-braket-sdk ~= 1.0"],
+    install_requires=["pytket ~= 0.18.0rc0", "amazon-braket-sdk ~= 1.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.7",

--- a/modules/pytket-cirq/setup.py
+++ b/modules/pytket-cirq/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket ~= 0.17.0",
+        "pytket ~= 0.18.0rc0",
         "cirq-core ~= 0.13.0",
         "cirq-google ~= 0.13.0",
     ],

--- a/modules/pytket-honeywell/setup.py
+++ b/modules/pytket-honeywell/setup.py
@@ -38,7 +38,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket ~= 0.17.0",
+        "pytket ~= 0.18.0rc0",
         "requests >= 2.2",
         "types-requests",
         "websockets >= 7.0",

--- a/modules/pytket-ionq/setup.py
+++ b/modules/pytket-ionq/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 0.17.0", "requests ~= 2.22", "types-requests"],
+    install_requires=["pytket ~= 0.18.0rc0", "requests ~= 2.22", "types-requests"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.7",

--- a/modules/pytket-projectq/setup.py
+++ b/modules/pytket-projectq/setup.py
@@ -38,7 +38,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 0.17.0", "projectq ~= 0.7.0"],
+    install_requires=["pytket ~= 0.18.0rc0", "projectq ~= 0.7.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.7",

--- a/modules/pytket-pyquil/setup.py
+++ b/modules/pytket-pyquil/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket ~= 0.17.0",
+        "pytket ~= 0.18.0rc0",
         "pyquil ~= 3.0",
         "typing-extensions ~= 3.7",
     ],

--- a/modules/pytket-pyzx/setup.py
+++ b/modules/pytket-pyzx/setup.py
@@ -38,7 +38,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 0.17.0", "pyzx ~= 0.6.3"],
+    install_requires=["pytket ~= 0.18.0rc0", "pyzx ~= 0.6.3"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.7",

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibm.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibm.py
@@ -45,7 +45,6 @@ from pytket.backends.backendinfo import BackendInfo
 from pytket.backends.backendresult import BackendResult
 from pytket.backends.resulthandle import _ResultIdTuple
 from pytket.extensions.qiskit.qiskit_convert import (
-    FullyConnected2,
     process_characterisation,
     get_avg_characterisation,
 )
@@ -74,7 +73,7 @@ from pytket.extensions.qiskit.qiskit_convert import tk_to_qiskit, _tk_gate_set
 from pytket.extensions.qiskit.result_convert import (
     qiskit_experimentresult_to_backendresult,
 )
-from pytket.routing import NoiseAwarePlacement  # type: ignore
+from pytket.routing import FullyConnected, NoiseAwarePlacement  # type: ignore
 from pytket.utils import prepare_circuit
 from pytket.utils.results import KwargTypes
 from .ibm_utils import _STATUS_MAP, _batch_circuits
@@ -412,7 +411,7 @@ class IBMQBackend(Backend):
             passlist.append(FullPeepholeOptimise())
         mid_measure = self._backend_info.supports_midcircuit_measurement
         arch = self._backend_info.architecture
-        if not isinstance(arch, FullyConnected2):
+        if not isinstance(arch, FullyConnected):
             passlist.append(
                 CXMappingPass(
                     arch,

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
@@ -65,7 +65,7 @@ from pytket.circuit import (  # type: ignore
     Qubit,
 )
 from pytket._tket.circuit import _TEMP_BIT_NAME  # type: ignore
-from pytket.routing import Architecture  # type: ignore
+from pytket.routing import Architecture, FullyConnected  # type: ignore
 
 if TYPE_CHECKING:
     from qiskit.providers.backend import BackendV1 as QiskitBackend  # type: ignore
@@ -552,24 +552,6 @@ def tk_to_qiskit(tkcirc: Circuit) -> QuantumCircuit:
     return qcirc
 
 
-class FullyConnected2(Architecture):
-    """A replacement FullyConnected architecture that doesn't build the full
-    matrix.
-    For use with large numbers of qubits, to avoid calculations/routing."""
-
-    def __init__(self, n_nodes: int) -> None:
-        super().__init__([])
-        self.n_nodes = n_nodes
-
-    @property
-    def nodes(self) -> List[Node]:
-        return [Node(i) for i in range(self.n_nodes)]
-
-    @property
-    def coupling(self) -> List[Tuple[Node, Node]]:
-        return NotImplemented
-
-
 def process_characterisation(backend: "QiskitBackend") -> Dict[str, Any]:
     """Convert a :py:class:`qiskit.providers.backend.Backendv1` to a dictionary
      containing device Characteristics
@@ -597,7 +579,7 @@ def process_characterisation(backend: "QiskitBackend") -> Dict[str, Any]:
     n_qubits = config.n_qubits
     if coupling_map is None:
         # Assume full connectivity
-        arc = FullyConnected2(n_qubits)
+        arc = FullyConnected(n_qubits)
     else:
         arc = Architecture(coupling_map)
 

--- a/modules/pytket-qiskit/setup.py
+++ b/modules/pytket-qiskit/setup.py
@@ -38,7 +38,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 0.17.0", "qiskit ~= 0.32.0"],
+    install_requires=["pytket ~= 0.18.0rc0", "qiskit ~= 0.32.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.7",

--- a/modules/pytket-qsharp/setup.py
+++ b/modules/pytket-qsharp/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket ~= 0.17.0",
+        "pytket ~= 0.18.0rc0",
         "qsharp ~= 0.21.2111",
         "qsharp-core ~= 0.21.2111",
     ],

--- a/modules/pytket-qulacs/setup.py
+++ b/modules/pytket-qulacs/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 0.17.0", "Qulacs ~= 0.3.0"],
+    install_requires=["pytket ~= 0.18.0rc0", "Qulacs ~= 0.3.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.7",

--- a/modules/pytket-stim/setup.py
+++ b/modules/pytket-stim/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 0.17.0", "stim ~= 1.4"],
+    install_requires=["pytket ~= 0.18.0rc0", "stim ~= 1.4"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
* Update pytket dependency to 0.18.0rc0;
* pytket-qiskit can go back to using `FullyConnected` instead of a custom `FullyConnected2`;
* pytket-braket should not use `FullyConnected` since it doesn't support coupling maps (use normal `Architecture` instead).
