### PR TITLE
Use released sphinx for building docs

### DIFF
--- a/.github/workflows/docs/requirements.txt
+++ b/.github/workflows/docs/requirements.txt
@@ -1,2 +1,2 @@
-git+git://github.com/yao-cqc/sphinx.git@ignore-mutated-finders-in-autodoc
+sphinx ~= 4.3.2
 sphinx_rtd_theme


### PR DESCRIPTION
resolves #89 

The issue that let us use the forked sphinx has been fixed by this [pr](https://github.com/quantumlib/Cirq/commit/9349802d924bb5d23753fe0e30e396e0ec84af38) since Cirq 0.13.0