### PR TITLE
Add IQM extension

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,7 @@
 /modules/pytket-cirq/ @sjdilkes
 /modules/pytket-honeywell/ @ss2165
 /modules/pytket-ionq/ @Roland-djee
+/modules/pytket-iqm/ @cqc-alec
 /modules/pytket-projectq/ @lmondada
 /modules/pytket-pyquil/ @sjdilkes @lmondada
 /modules/pytket-pyzx/ @cqc-alec

--- a/.github/workflows/build-test
+++ b/.github/workflows/build-test
@@ -19,6 +19,8 @@ MYPY=$1
 
 PLAT=`python -c 'import platform; print(platform.system())'`
 
+PYVER=`python -c 'import sys; print(".".join(map(str, sys.version_info[:2])))'`
+
 git clean -dfx
 
 echo "Modules to test: ${MODULES_TO_TEST}"
@@ -33,13 +35,15 @@ python -m pip install --upgrade pip wheel
 
 # Generate and install packages:
 for MODULE in $MODULES_TO_TEST; do
-    echo "${MODULE}..."
-    cd ${MODULEDIR}/${MODULE}
-    python setup.py sdist
-    for sdist in dist/*.tar.gz ; do
-        python -m pip install $sdist
-        cp $sdist ${ARTIFACTSDIR}
-    done
+    if [[ "${MODULE}" != "pytket-iqm" || "${PYVER}" == "3.9" ]]; then
+        echo "${MODULE}..."
+        cd ${MODULEDIR}/${MODULE}
+        python setup.py sdist
+        for sdist in dist/*.tar.gz ; do
+            python -m pip install $sdist
+            cp $sdist ${ARTIFACTSDIR}
+        done
+    fi
 done
 
 # Test and mypy:
@@ -48,29 +52,30 @@ then
     python -m pip install --upgrade mypy
 fi
 for MODULE in $MODULES_TO_TEST; do
-
-    # FIXME see
-    # https://github.com/CQCL/pytket-extensions/issues/180 and 
-    # https://github.com/microsoft/iqsharp/issues/512
-    PYVER=`python -c 'import sys; print(".".join(map(str, sys.version_info[:2])))'`
-    if [[ "${MODULE}" != "pytket-qsharp" || "${PLAT}" != "Windows" || "${PYVER}" == "3.7" ]]
-    then
-        echo "${MODULE}..."
-
-        cd ${MODULEDIR}/${MODULE}/tests
-
-        python -m pip install --pre -r test-requirements.txt
-
-        if [[ "${MODULE}" = "pytket-qsharp" && "${PLAT}" != "Darwin" ]]
+    # pytket-iqm not supported with 3.7 or 3.8
+    if [[ "${MODULE}" != "pytket-iqm" || "${PYVER}" == "3.9" ]]; then
+        # FIXME see
+        # https://github.com/CQCL/pytket-extensions/issues/180 and
+        # https://github.com/microsoft/iqsharp/issues/512
+        if [[ "${MODULE}" != "pytket-qsharp" || "${PLAT}" != "Windows" || "${PYVER}" == "3.7" ]]
         then
-            dotnet iqsharp install --user
-        fi
+            echo "${MODULE}..."
 
-        pytest --doctest-modules
+            cd ${MODULEDIR}/${MODULE}/tests
 
-        if [[ "${MYPY}" = "mypy" ]]
-        then
-            ${MODULEDIR}/mypy-check ${MODULEDIR}/${MODULE}
+            python -m pip install --pre -r test-requirements.txt
+
+            if [[ "${MODULE}" = "pytket-qsharp" && "${PLAT}" != "Darwin" ]]
+            then
+                dotnet iqsharp install --user
+            fi
+
+            pytest --doctest-modules
+
+            if [[ "${MYPY}" = "mypy" ]]
+            then
+                ${MODULEDIR}/mypy-check ${MODULEDIR}/${MODULE}
+            fi
         fi
     fi
 done

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -147,12 +147,12 @@ jobs:
         ./.github/workflows/build-test mypy
 
     - name: Set up Python 3.9
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'pull_request'
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
     - name: Build and test (3.9)
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'pull_request'
       run: |
         ./.github/workflows/build-test nomypy
 
@@ -211,12 +211,12 @@ jobs:
       run: |
         ./.github/workflows/build-test nomypy
     - name: Set up Python 3.9
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'pull_request'
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
     - name: Build and test (3.9)
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'pull_request'
       shell: bash
       run: |
         ./.github/workflows/build-test nomypy

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -74,12 +74,11 @@ jobs:
       run: |
         ./.github/workflows/build-test nomypy
     - name: Set up Python 3.9
-      if: github.event_name == 'push' || github.event_name == 'release' || contains(github.ref, 'refs/heads/wheel')
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
     - name: Build and test (3.9)
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'pull_request'
       run: |
         ./.github/workflows/build-test nomypy
     - name: Build, test and save (3.9)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ subdirectory of the `modules` directory:
 * `pytket-cirq`
 * `pytket-honeywell`
 * `pytket-ionq`
+* `pytket-iqm`
 * `pytket-projectq`
 * `pytket-pyquil`
 * `pytket-pyzx`

--- a/modules/pytket-iqm/MANIFEST.in
+++ b/modules/pytket-iqm/MANIFEST.in
@@ -1,0 +1,3 @@
+include _metadata.py
+include pytket/extensions/iqm/py.typed
+include pytket/extensions/iqm/backends/demo_settings.json

--- a/modules/pytket-iqm/README.md
+++ b/modules/pytket-iqm/README.md
@@ -1,7 +1,7 @@
 # pytket-iqm
 
-[Pytket](https://cqcl.github.io/pytket) is a Python module for interfacing
-with CQC tket, a set of quantum programming tools.
+[Pytket](https://cqcl.github.io/pytket) is a Python module providing an
+extensive set of tools for compiling and executing quantum circuits.
 
 `pytket-iqm` is an extension to `pytket` that allows `pytket` circuits to be
 executed on [IQM](https://meetiqm.com/)'s quantum devices and simulators.

--- a/modules/pytket-iqm/README.md
+++ b/modules/pytket-iqm/README.md
@@ -1,0 +1,14 @@
+# pytket-iqm
+
+[Pytket](https://cqcl.github.io/pytket) is a Python module for interfacing
+with CQC tket, a set of quantum programming tools.
+
+`pytket-iqm` is an extension to `pytket` that allows `pytket` circuits to be
+executed on [IQM](https://meetiqm.com/)'s quantum devices and simulators.
+
+## Getting started
+
+`pytket-iqm` is available for Python 3.9, on Linux, MacOS and Windows. To
+install, run:
+
+```pip install pytket-iqm```

--- a/modules/pytket-iqm/_metadata.py
+++ b/modules/pytket-iqm/_metadata.py
@@ -1,0 +1,2 @@
+__extension_version__ = "0.1.0"
+__extension_name__ = "pytket-iqm"

--- a/modules/pytket-iqm/docs/api.rst
+++ b/modules/pytket-iqm/docs/api.rst
@@ -1,0 +1,10 @@
+API documentation
+~~~~~~~~~~~~~~~~~
+
+.. automodule:: pytket.extensions.iqm
+    :special-members:
+    :members: IQMBackend
+
+
+.. automodule:: pytket.extensions.iqm.backends.config
+    :members:

--- a/modules/pytket-iqm/docs/changelog.rst
+++ b/modules/pytket-iqm/docs/changelog.rst
@@ -1,0 +1,7 @@
+Changelog
+~~~~~~~~~
+
+0.1.0 (unreleased)
+------------------
+
+* Initial release.

--- a/modules/pytket-iqm/docs/intro.txt
+++ b/modules/pytket-iqm/docs/intro.txt
@@ -1,0 +1,18 @@
+pytket-iqm
+==========
+
+.. image:: CQCLogo.png
+   :width: 120px
+   :align: right
+
+``pytket-iqm`` is an extension to ``pytket`` that allows ``pytket`` circuits to
+be executed on IQM's quantum devices and simulators.
+
+``pytket-iqm`` is available for Python 3.9, on Linux, MacOS and Windows. To
+install, run:
+
+``pip install pytket-iqm``
+
+.. toctree::
+    api.rst
+    changelog.rst

--- a/modules/pytket-iqm/pytket/extensions/iqm/__init__.py
+++ b/modules/pytket-iqm/pytket/extensions/iqm/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2020-2022 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backends for processing pytket circuits with IQM devices
+"""
+
+# _metadata.py is copied to the folder after installation.
+from ._metadata import __extension_version__, __extension_name__  # type: ignore
+from .backends import IQMBackend
+from .backends.config import IQMConfig, set_iqm_config

--- a/modules/pytket-iqm/pytket/extensions/iqm/backends/__init__.py
+++ b/modules/pytket-iqm/pytket/extensions/iqm/backends/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2020-2022 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backends for processing pytket circuits with IQM devices
+"""
+
+from .iqm import IQMBackend

--- a/modules/pytket-iqm/pytket/extensions/iqm/backends/config.py
+++ b/modules/pytket-iqm/pytket/extensions/iqm/backends/config.py
@@ -1,0 +1,49 @@
+# Copyright 2020-2022 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""IQM config."""
+
+from typing import Any, Dict, Optional, Type, ClassVar
+from dataclasses import dataclass
+from pytket.config import PytketExtConfig
+
+
+@dataclass
+class IQMConfig(PytketExtConfig):
+    """Holds config parameters for pytket-iqm."""
+
+    ext_dict_key: ClassVar[str] = "iqm"
+
+    username: Optional[str]
+
+    api_key: Optional[str]
+
+    @classmethod
+    def from_extension_dict(
+        cls: Type["IQMConfig"], ext_dict: Dict[str, Any]
+    ) -> "IQMConfig":
+        return cls(ext_dict.get("username", None), ext_dict.get("api_key", None))
+
+
+def set_iqm_config(
+    username: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> None:
+    """Set default value for IQM API token."""
+    config = IQMConfig.from_default_config_file()
+    if username is not None:
+        config.username = username
+    if api_key is not None:
+        config.api_key = api_key
+    config.update_default_config_file()

--- a/modules/pytket-iqm/pytket/extensions/iqm/backends/demo_settings.json
+++ b/modules/pytket-iqm/pytket/extensions/iqm/backends/demo_settings.json
@@ -1,0 +1,6513 @@
+{
+    "name": "root",
+    "settings": {},
+    "subtrees": {
+        "QB1": {
+            "name": "QB1",
+            "settings": {},
+            "subtrees": {
+                "drive": {
+                    "name": "drive_1",
+                    "settings": {},
+                    "subtrees": {
+                        "awg": {
+                            "name": "drive_1.awg",
+                            "settings": {
+                                "continuous_wave_amplitude": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Continuous sine output amplitude",
+                                        "name": "drive_1.awg.continuous_wave_amplitude",
+                                        "unit": ""
+                                    },
+                                    "value": 0
+                                },
+                                "continuous_wave_enabled": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Continuous wave mode",
+                                        "name": "drive_1.awg.continuous_wave_enabled",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "dac_downsampling_factor": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "DAC downsampling factor",
+                                        "name": "drive_1.awg.dac_downsampling_factor",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "dac_rate": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "DAC rate",
+                                        "name": "drive_1.awg.dac_rate",
+                                        "unit": "Hz"
+                                    },
+                                    "value": null
+                                },
+                                "end_delay": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Delay after pulse",
+                                        "name": "drive_1.awg.end_delay",
+                                        "unit": "s"
+                                    },
+                                    "value": 0
+                                },
+                                "full_routing_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Full routing mode",
+                                        "name": "drive_1.awg.full_routing_mode",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "is_master": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Is trigger master",
+                                        "name": "drive_1.awg.is_master",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                },
+                                "max_output": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output ranges",
+                                        "name": "drive_1.awg.max_output",
+                                        "unit": "V"
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_0_gains_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 0 gain 0",
+                                        "name": "drive_1.awg.outputs_0_gains_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_0_gains_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 0 gain 1",
+                                        "name": "drive_1.awg.outputs_0_gains_1",
+                                        "unit": ""
+                                    },
+                                    "value": -1.0
+                                },
+                                "outputs_0_modulation_carrier_0_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 0 oscillator",
+                                        "name": "drive_1.awg.outputs_0_modulation_carrier_0_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_0_modulation_carrier_0_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 0 phase",
+                                        "name": "drive_1.awg.outputs_0_modulation_carrier_0_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": 0
+                                },
+                                "outputs_0_modulation_carrier_1_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 1 oscillator",
+                                        "name": "drive_1.awg.outputs_0_modulation_carrier_1_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_0_modulation_carrier_1_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 1 phase",
+                                        "name": "drive_1.awg.outputs_0_modulation_carrier_1_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": -90
+                                },
+                                "outputs_0_modulation_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG output 0 modulation mode",
+                                        "name": "drive_1.awg.outputs_0_modulation_mode",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "outputs_1_gains_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 1 gain 0",
+                                        "name": "drive_1.awg.outputs_1_gains_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_1_gains_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 1 gain 1",
+                                        "name": "drive_1.awg.outputs_1_gains_1",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_1_modulation_carrier_0_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 0 oscillator",
+                                        "name": "drive_1.awg.outputs_1_modulation_carrier_0_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_1_modulation_carrier_0_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 0 phase",
+                                        "name": "drive_1.awg.outputs_1_modulation_carrier_0_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": 0
+                                },
+                                "outputs_1_modulation_carrier_1_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 1 oscillator",
+                                        "name": "drive_1.awg.outputs_1_modulation_carrier_1_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_1_modulation_carrier_1_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 1 phase",
+                                        "name": "drive_1.awg.outputs_1_modulation_carrier_1_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": -90
+                                },
+                                "outputs_1_modulation_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG output 1 modulation mode",
+                                        "name": "drive_1.awg.outputs_1_modulation_mode",
+                                        "unit": ""
+                                    },
+                                    "value": 2
+                                },
+                                "phase_sensitive_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Phase sensitive mode",
+                                        "name": "drive_1.awg.phase_sensitive_mode",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                },
+                                "phase_shift_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 0 phase",
+                                        "name": "drive_1.awg.phase_shift_0",
+                                        "unit": "rad"
+                                    },
+                                    "value": 0
+                                },
+                                "phase_shift_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 1 phase",
+                                        "name": "drive_1.awg.phase_shift_1",
+                                        "unit": "rad"
+                                    },
+                                    "value": -1.5707963267948966
+                                },
+                                "playlist_repeats": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Number of repetitions",
+                                        "name": "drive_1.awg.playlist_repeats",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "sigouts_0_offset": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output 0 offset",
+                                        "name": "drive_1.awg.sigouts_0_offset",
+                                        "unit": "V"
+                                    },
+                                    "value": 0
+                                },
+                                "sigouts_1_offset": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output 1 offset",
+                                        "name": "drive_1.awg.sigouts_1_offset",
+                                        "unit": "V"
+                                    },
+                                    "value": 0
+                                },
+                                "sines_0_amplitudes_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 0 amplitude to wave output 0",
+                                        "name": "drive_1.awg.sines_0_amplitudes_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "sines_1_amplitudes_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 1 amplitude to wave output 1",
+                                        "name": "drive_1.awg.sines_1_amplitudes_1",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "status": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Output enabled",
+                                        "name": "drive_1.awg.status",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                },
+                                "trigger_delay": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Delay between trigger output and pulse",
+                                        "name": "drive_1.awg.trigger_delay",
+                                        "unit": "s"
+                                    },
+                                    "value": 0
+                                },
+                                "trigger_source": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Source of digital trigger",
+                                        "name": "drive_1.awg.trigger_source",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                }
+                            },
+                            "subtrees": {}
+                        },
+                        "local_oscillator": {
+                            "name": "drive_1.local_oscillator",
+                            "settings": {
+                                "frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "LO frequency",
+                                        "name": "drive_1.local_oscillator.frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": null
+                                },
+                                "phase": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Phase",
+                                        "name": "drive_1.local_oscillator.phase",
+                                        "unit": "deg"
+                                    },
+                                    "value": null
+                                },
+                                "power": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Power",
+                                        "name": "drive_1.local_oscillator.power",
+                                        "unit": "dBm"
+                                    },
+                                    "value": 13
+                                },
+                                "status": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "RF output enabled",
+                                        "name": "drive_1.local_oscillator.status",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                }
+                            },
+                            "subtrees": {}
+                        },
+                        "pi_pulse": {
+                            "name": "drive_1.pi_pulse",
+                            "settings": {},
+                            "subtrees": {
+                                "channel_0": {
+                                    "name": "drive_1.pi_pulse.channel_0",
+                                    "settings": {
+                                        "amplitude": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": [
+                                                    1,
+                                                    2
+                                                ],
+                                                "label": "Pulse Amplitude",
+                                                "name": "drive_1.pi_pulse.channel_0.amplitude",
+                                                "unit": ""
+                                            },
+                                            "value": 1.0
+                                        },
+                                        "csv_dir": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse CSV Directory",
+                                                "name": "drive_1.pi_pulse.channel_0.csv_dir",
+                                                "unit": ""
+                                            },
+                                            "value": null
+                                        },
+                                        "duration": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Duration",
+                                                "name": "drive_1.pi_pulse.channel_0.duration",
+                                                "unit": "s"
+                                            },
+                                            "value": 1e-07
+                                        },
+                                        "duration_type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Duration Type",
+                                                "name": "drive_1.pi_pulse.channel_0.duration_type",
+                                                "unit": ""
+                                            },
+                                            "value": "TIME"
+                                        },
+                                        "phase": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Phase",
+                                                "name": "drive_1.pi_pulse.channel_0.phase",
+                                                "unit": "rad"
+                                            },
+                                            "value": 0.0
+                                        },
+                                        "program_mode": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Program Mode",
+                                                "name": "drive_1.pi_pulse.channel_0.program_mode",
+                                                "unit": ""
+                                            },
+                                            "value": "PREDEFINED"
+                                        },
+                                        "sampling_rate": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Sample Rate",
+                                                "name": "drive_1.pi_pulse.channel_0.sample_rate",
+                                                "unit": "Hz"
+                                            },
+                                            "value": 2400000000
+                                        },
+                                        "type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Type",
+                                                "name": "drive_1.pi_pulse.channel_0.type",
+                                                "unit": ""
+                                            },
+                                            "value": "GaussianPulse"
+                                        },
+                                        "width": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Width",
+                                                "name": "drive_1.pi_pulse.channel_0.width",
+                                                "unit": "sec"
+                                            },
+                                            "value": 2.5e-08
+                                        }
+                                    },
+                                    "subtrees": {}
+                                },
+                                "channel_1": {
+                                    "name": "drive_1.pi_pulse.channel_1",
+                                    "settings": {
+                                        "amplitude": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": [
+                                                    1,
+                                                    2
+                                                ],
+                                                "label": "Pulse Amplitude",
+                                                "name": "drive_1.pi_pulse.channel_1.amplitude",
+                                                "unit": ""
+                                            },
+                                            "value": 0.0
+                                        },
+                                        "csv_dir": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse CSV Directory",
+                                                "name": "drive_1.pi_pulse.channel_1.csv_dir",
+                                                "unit": ""
+                                            },
+                                            "value": null
+                                        },
+                                        "duration": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Duration",
+                                                "name": "drive_1.pi_pulse.channel_1.duration",
+                                                "unit": "s"
+                                            },
+                                            "value": 1e-07
+                                        },
+                                        "duration_type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Duration Type",
+                                                "name": "drive_1.pi_pulse.channel_1.duration_type",
+                                                "unit": ""
+                                            },
+                                            "value": "TIME"
+                                        },
+                                        "phase": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Phase",
+                                                "name": "drive_1.pi_pulse.channel_1.phase",
+                                                "unit": "rad"
+                                            },
+                                            "value": 0.0
+                                        },
+                                        "program_mode": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Program Mode",
+                                                "name": "drive_1.pi_pulse.channel_1.program_mode",
+                                                "unit": ""
+                                            },
+                                            "value": "PREDEFINED"
+                                        },
+                                        "sampling_rate": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Sample Rate",
+                                                "name": "drive_1.pi_pulse.channel_1.sample_rate",
+                                                "unit": "Hz"
+                                            },
+                                            "value": 2400000000
+                                        },
+                                        "type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Type",
+                                                "name": "drive_1.pi_pulse.channel_1.type",
+                                                "unit": ""
+                                            },
+                                            "value": "GaussianDerivativePulse"
+                                        },
+                                        "width": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Width",
+                                                "name": "drive_1.pi_pulse.channel_1.width",
+                                                "unit": "sec"
+                                            },
+                                            "value": 2.5e-08
+                                        }
+                                    },
+                                    "subtrees": {}
+                                }
+                            }
+                        },
+                        "upconverter": {
+                            "name": "drive_1.upconverter",
+                            "settings": {
+                                "frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "RF frequency",
+                                        "name": "drive_1.upconverter.frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": 3980000000
+                                },
+                                "max_intermediate_frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Max IF frequency",
+                                        "name": "drive_1.upconverter.max_intermediate_frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": -300000000
+                                },
+                                "min_intermediate_frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Min IF frequency",
+                                        "name": "drive_1.upconverter.min_intermediate_frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": -300000000
+                                }
+                            },
+                            "subtrees": {}
+                        }
+                    }
+                },
+                "flux": {
+                    "name": "flux_1",
+                    "settings": {
+                        "voltage": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Gate dac1",
+                                "name": "flux_1.voltage",
+                                "unit": "V"
+                            },
+                            "value": 0
+                        }
+                    },
+                    "subtrees": {}
+                },
+                "readout": {
+                    "name": "readout_1",
+                    "settings": {
+                        "channel_pulse_amplitude": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Channel readout amplitude",
+                                "name": "readout_1.channel_pulse_amplitude",
+                                "unit": ""
+                            },
+                            "value": 0.2
+                        },
+                        "channel_pulse_ratio": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Ratio of I and Q amplitudes",
+                                "name": "readout_1.channel_pulse_ratio",
+                                "unit": ""
+                            },
+                            "value": 1
+                        },
+                        "correlation_source": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Correlation source",
+                                "name": "readout_1.correlation_source",
+                                "unit": ""
+                            },
+                            "value": null
+                        },
+                        "enabled_pulse_slots": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 4,
+                                "label": "Enabled pulse slots",
+                                "name": "readout_1.enabled_pulse_slots",
+                                "unit": ""
+                            },
+                            "value": [
+                                false,
+                                true
+                            ]
+                        },
+                        "frequency": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "RF frequency",
+                                "name": "readout_1.frequency",
+                                "unit": "Hz"
+                            },
+                            "value": 5275000000
+                        },
+                        "integration_threshold": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Integration threshold",
+                                "name": "readout_1.integration_threshold",
+                                "unit": ""
+                            },
+                            "value": 0.5
+                        },
+                        "integration_weights_I": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 1,
+                                "label": "Integration weights I",
+                                "name": "readout_1.integration_weights_I",
+                                "unit": ""
+                            },
+                            "value": null
+                        },
+                        "integration_weights_Q": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 1,
+                                "label": "Integration weights Q",
+                                "name": "readout_1.integration_weights_Q",
+                                "unit": ""
+                            },
+                            "value": null
+                        },
+                        "integrator_channels": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 1,
+                                "label": "Source channel indices",
+                                "name": "readout_1.integrator_channels",
+                                "unit": ""
+                            },
+                            "value": []
+                        },
+                        "intermediate_frequency": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "IF frequency",
+                                "name": "readout_1.intermediate_frequency",
+                                "unit": "Hz"
+                            },
+                            "value": 200000000
+                        },
+                        "modulate_weights": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 4,
+                                "label": "Modulate weights",
+                                "name": "readout_1.modulate_weights",
+                                "unit": ""
+                            },
+                            "value": true
+                        },
+                        "phase": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Readout pulse phase",
+                                "name": "readout_1.phase",
+                                "unit": "rad"
+                            },
+                            "value": 0
+                        },
+                        "pulse_length": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Readout pulse duration",
+                                "name": "readout_1.pulse_length",
+                                "unit": "s"
+                            },
+                            "value": 2e-06
+                        },
+                        "result": {
+                            "parameter": {
+                                "collection_type": 2,
+                                "data_type": 2,
+                                "label": "Readout signal",
+                                "name": "readout_1.result",
+                                "unit": "V"
+                            },
+                            "value": null
+                        },
+                        "result_type": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 3,
+                                "label": "Acquisition type of result",
+                                "name": "readout_1.result_type",
+                                "unit": ""
+                            },
+                            "value": "threshold"
+                        },
+                        "sampling_rate": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Sampling rate",
+                                "name": "readout_1.sampling_rate",
+                                "unit": "Sa/s"
+                            },
+                            "value": 1800000000.0
+                        }
+                    },
+                    "subtrees": {}
+                }
+            }
+        },
+        "QB2": {
+            "name": "QB2",
+            "settings": {},
+            "subtrees": {
+                "drive": {
+                    "name": "drive_2",
+                    "settings": {},
+                    "subtrees": {
+                        "awg": {
+                            "name": "drive_2.awg",
+                            "settings": {
+                                "continuous_wave_amplitude": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Continuous sine output amplitude",
+                                        "name": "drive_2.awg.continuous_wave_amplitude",
+                                        "unit": ""
+                                    },
+                                    "value": 0
+                                },
+                                "continuous_wave_enabled": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Continuous wave mode",
+                                        "name": "drive_2.awg.continuous_wave_enabled",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "dac_downsampling_factor": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "DAC downsampling factor",
+                                        "name": "drive_2.awg.dac_downsampling_factor",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "dac_rate": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "DAC rate",
+                                        "name": "drive_2.awg.dac_rate",
+                                        "unit": "Hz"
+                                    },
+                                    "value": null
+                                },
+                                "end_delay": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Delay after pulse",
+                                        "name": "drive_2.awg.end_delay",
+                                        "unit": "s"
+                                    },
+                                    "value": 0
+                                },
+                                "full_routing_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Full routing mode",
+                                        "name": "drive_2.awg.full_routing_mode",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "is_master": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Is trigger master",
+                                        "name": "drive_2.awg.is_master",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "max_output": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output ranges",
+                                        "name": "drive_2.awg.max_output",
+                                        "unit": "V"
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_0_gains_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 0 gain 0",
+                                        "name": "drive_2.awg.outputs_0_gains_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_0_gains_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 0 gain 1",
+                                        "name": "drive_2.awg.outputs_0_gains_1",
+                                        "unit": ""
+                                    },
+                                    "value": -1.0
+                                },
+                                "outputs_0_modulation_carrier_0_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 0 oscillator",
+                                        "name": "drive_2.awg.outputs_0_modulation_carrier_0_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_0_modulation_carrier_0_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 0 phase",
+                                        "name": "drive_2.awg.outputs_0_modulation_carrier_0_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": 0
+                                },
+                                "outputs_0_modulation_carrier_1_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 1 oscillator",
+                                        "name": "drive_2.awg.outputs_0_modulation_carrier_1_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_0_modulation_carrier_1_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 1 phase",
+                                        "name": "drive_2.awg.outputs_0_modulation_carrier_1_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": -90
+                                },
+                                "outputs_0_modulation_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG output 0 modulation mode",
+                                        "name": "drive_2.awg.outputs_0_modulation_mode",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "outputs_1_gains_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 1 gain 0",
+                                        "name": "drive_2.awg.outputs_1_gains_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_1_gains_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 1 gain 1",
+                                        "name": "drive_2.awg.outputs_1_gains_1",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_1_modulation_carrier_0_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 0 oscillator",
+                                        "name": "drive_2.awg.outputs_1_modulation_carrier_0_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_1_modulation_carrier_0_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 0 phase",
+                                        "name": "drive_2.awg.outputs_1_modulation_carrier_0_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": 0
+                                },
+                                "outputs_1_modulation_carrier_1_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 1 oscillator",
+                                        "name": "drive_2.awg.outputs_1_modulation_carrier_1_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_1_modulation_carrier_1_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 1 phase",
+                                        "name": "drive_2.awg.outputs_1_modulation_carrier_1_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": -90
+                                },
+                                "outputs_1_modulation_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG output 1 modulation mode",
+                                        "name": "drive_2.awg.outputs_1_modulation_mode",
+                                        "unit": ""
+                                    },
+                                    "value": 2
+                                },
+                                "phase_sensitive_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Phase sensitive mode",
+                                        "name": "drive_2.awg.phase_sensitive_mode",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                },
+                                "phase_shift_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 0 phase",
+                                        "name": "drive_2.awg.phase_shift_0",
+                                        "unit": "rad"
+                                    },
+                                    "value": 0
+                                },
+                                "phase_shift_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 1 phase",
+                                        "name": "drive_2.awg.phase_shift_1",
+                                        "unit": "rad"
+                                    },
+                                    "value": -1.5707963267948966
+                                },
+                                "playlist_repeats": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Number of repetitions",
+                                        "name": "drive_2.awg.playlist_repeats",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "sigouts_0_offset": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output 0 offset",
+                                        "name": "drive_2.awg.sigouts_0_offset",
+                                        "unit": "V"
+                                    },
+                                    "value": 0
+                                },
+                                "sigouts_1_offset": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output 1 offset",
+                                        "name": "drive_2.awg.sigouts_1_offset",
+                                        "unit": "V"
+                                    },
+                                    "value": 0
+                                },
+                                "sines_0_amplitudes_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 0 amplitude to wave output 0",
+                                        "name": "drive_2.awg.sines_0_amplitudes_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "sines_1_amplitudes_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 1 amplitude to wave output 1",
+                                        "name": "drive_2.awg.sines_1_amplitudes_1",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "status": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Output enabled",
+                                        "name": "drive_2.awg.status",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                },
+                                "trigger_delay": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Delay between trigger output and pulse",
+                                        "name": "drive_2.awg.trigger_delay",
+                                        "unit": "s"
+                                    },
+                                    "value": 0
+                                },
+                                "trigger_source": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Source of digital trigger",
+                                        "name": "drive_2.awg.trigger_source",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                }
+                            },
+                            "subtrees": {}
+                        },
+                        "local_oscillator": {
+                            "name": "drive_2.local_oscillator",
+                            "settings": {
+                                "frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "LO frequency",
+                                        "name": "drive_2.local_oscillator.frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": null
+                                },
+                                "phase": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Phase",
+                                        "name": "drive_2.local_oscillator.phase",
+                                        "unit": "deg"
+                                    },
+                                    "value": null
+                                },
+                                "power": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Power",
+                                        "name": "drive_2.local_oscillator.power",
+                                        "unit": "dBm"
+                                    },
+                                    "value": 13
+                                },
+                                "status": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "RF output enabled",
+                                        "name": "drive_2.local_oscillator.status",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                }
+                            },
+                            "subtrees": {}
+                        },
+                        "pi_pulse": {
+                            "name": "drive_2.pi_pulse",
+                            "settings": {},
+                            "subtrees": {
+                                "channel_0": {
+                                    "name": "drive_2.pi_pulse.channel_0",
+                                    "settings": {
+                                        "amplitude": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": [
+                                                    1,
+                                                    2
+                                                ],
+                                                "label": "Pulse Amplitude",
+                                                "name": "drive_2.pi_pulse.channel_0.amplitude",
+                                                "unit": ""
+                                            },
+                                            "value": 1.0
+                                        },
+                                        "csv_dir": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse CSV Directory",
+                                                "name": "drive_2.pi_pulse.channel_0.csv_dir",
+                                                "unit": ""
+                                            },
+                                            "value": null
+                                        },
+                                        "duration": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Duration",
+                                                "name": "drive_2.pi_pulse.channel_0.duration",
+                                                "unit": "s"
+                                            },
+                                            "value": 1e-07
+                                        },
+                                        "duration_type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Duration Type",
+                                                "name": "drive_2.pi_pulse.channel_0.duration_type",
+                                                "unit": ""
+                                            },
+                                            "value": "TIME"
+                                        },
+                                        "phase": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Phase",
+                                                "name": "drive_2.pi_pulse.channel_0.phase",
+                                                "unit": "rad"
+                                            },
+                                            "value": 0.0
+                                        },
+                                        "program_mode": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Program Mode",
+                                                "name": "drive_2.pi_pulse.channel_0.program_mode",
+                                                "unit": ""
+                                            },
+                                            "value": "PREDEFINED"
+                                        },
+                                        "sampling_rate": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Sample Rate",
+                                                "name": "drive_2.pi_pulse.channel_0.sample_rate",
+                                                "unit": "Hz"
+                                            },
+                                            "value": 2400000000
+                                        },
+                                        "type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Type",
+                                                "name": "drive_2.pi_pulse.channel_0.type",
+                                                "unit": ""
+                                            },
+                                            "value": "GaussianPulse"
+                                        },
+                                        "width": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Width",
+                                                "name": "drive_2.pi_pulse.channel_0.width",
+                                                "unit": "sec"
+                                            },
+                                            "value": 2.5e-08
+                                        }
+                                    },
+                                    "subtrees": {}
+                                },
+                                "channel_1": {
+                                    "name": "drive_2.pi_pulse.channel_1",
+                                    "settings": {
+                                        "amplitude": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": [
+                                                    1,
+                                                    2
+                                                ],
+                                                "label": "Pulse Amplitude",
+                                                "name": "drive_2.pi_pulse.channel_1.amplitude",
+                                                "unit": ""
+                                            },
+                                            "value": 0.0
+                                        },
+                                        "csv_dir": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse CSV Directory",
+                                                "name": "drive_2.pi_pulse.channel_1.csv_dir",
+                                                "unit": ""
+                                            },
+                                            "value": null
+                                        },
+                                        "duration": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Duration",
+                                                "name": "drive_2.pi_pulse.channel_1.duration",
+                                                "unit": "s"
+                                            },
+                                            "value": 1e-07
+                                        },
+                                        "duration_type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Duration Type",
+                                                "name": "drive_2.pi_pulse.channel_1.duration_type",
+                                                "unit": ""
+                                            },
+                                            "value": "TIME"
+                                        },
+                                        "phase": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Phase",
+                                                "name": "drive_2.pi_pulse.channel_1.phase",
+                                                "unit": "rad"
+                                            },
+                                            "value": 0.0
+                                        },
+                                        "program_mode": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Program Mode",
+                                                "name": "drive_2.pi_pulse.channel_1.program_mode",
+                                                "unit": ""
+                                            },
+                                            "value": "PREDEFINED"
+                                        },
+                                        "sampling_rate": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Sample Rate",
+                                                "name": "drive_2.pi_pulse.channel_1.sample_rate",
+                                                "unit": "Hz"
+                                            },
+                                            "value": 2400000000
+                                        },
+                                        "type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Type",
+                                                "name": "drive_2.pi_pulse.channel_1.type",
+                                                "unit": ""
+                                            },
+                                            "value": "GaussianDerivativePulse"
+                                        },
+                                        "width": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Width",
+                                                "name": "drive_2.pi_pulse.channel_1.width",
+                                                "unit": "sec"
+                                            },
+                                            "value": 2.5e-08
+                                        }
+                                    },
+                                    "subtrees": {}
+                                }
+                            }
+                        },
+                        "upconverter": {
+                            "name": "drive_2.upconverter",
+                            "settings": {
+                                "frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "RF frequency",
+                                        "name": "drive_2.upconverter.frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": 4184700000
+                                },
+                                "max_intermediate_frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Max IF frequency",
+                                        "name": "drive_2.upconverter.max_intermediate_frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": -300000000
+                                },
+                                "min_intermediate_frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Min IF frequency",
+                                        "name": "drive_2.upconverter.min_intermediate_frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": -300000000
+                                }
+                            },
+                            "subtrees": {}
+                        }
+                    }
+                },
+                "flux": {
+                    "name": "flux_2",
+                    "settings": {
+                        "voltage": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Gate dac1",
+                                "name": "flux_2.voltage",
+                                "unit": "V"
+                            },
+                            "value": 0
+                        }
+                    },
+                    "subtrees": {}
+                },
+                "readout": {
+                    "name": "readout_2",
+                    "settings": {
+                        "channel_pulse_amplitude": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Channel readout amplitude",
+                                "name": "readout_2.channel_pulse_amplitude",
+                                "unit": ""
+                            },
+                            "value": 0.2
+                        },
+                        "channel_pulse_ratio": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Ratio of I and Q amplitudes",
+                                "name": "readout_2.channel_pulse_ratio",
+                                "unit": ""
+                            },
+                            "value": 1
+                        },
+                        "correlation_source": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Correlation source",
+                                "name": "readout_2.correlation_source",
+                                "unit": ""
+                            },
+                            "value": null
+                        },
+                        "enabled_pulse_slots": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 4,
+                                "label": "Enabled pulse slots",
+                                "name": "readout_2.enabled_pulse_slots",
+                                "unit": ""
+                            },
+                            "value": [
+                                false,
+                                true
+                            ]
+                        },
+                        "frequency": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "RF frequency",
+                                "name": "readout_2.frequency",
+                                "unit": "Hz"
+                            },
+                            "value": 4950000000
+                        },
+                        "integration_threshold": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Integration threshold",
+                                "name": "readout_2.integration_threshold",
+                                "unit": ""
+                            },
+                            "value": 0.5
+                        },
+                        "integration_weights_I": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 1,
+                                "label": "Integration weights I",
+                                "name": "readout_2.integration_weights_I",
+                                "unit": ""
+                            },
+                            "value": null
+                        },
+                        "integration_weights_Q": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 1,
+                                "label": "Integration weights Q",
+                                "name": "readout_2.integration_weights_Q",
+                                "unit": ""
+                            },
+                            "value": null
+                        },
+                        "integrator_channels": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 1,
+                                "label": "Source channel indices",
+                                "name": "readout_2.integrator_channels",
+                                "unit": ""
+                            },
+                            "value": []
+                        },
+                        "intermediate_frequency": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "IF frequency",
+                                "name": "readout_2.intermediate_frequency",
+                                "unit": "Hz"
+                            },
+                            "value": 200000000
+                        },
+                        "modulate_weights": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 4,
+                                "label": "Modulate weights",
+                                "name": "readout_2.modulate_weights",
+                                "unit": ""
+                            },
+                            "value": true
+                        },
+                        "phase": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Readout pulse phase",
+                                "name": "readout_2.phase",
+                                "unit": "rad"
+                            },
+                            "value": 0
+                        },
+                        "pulse_length": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Readout pulse duration",
+                                "name": "readout_2.pulse_length",
+                                "unit": "s"
+                            },
+                            "value": 2e-06
+                        },
+                        "result": {
+                            "parameter": {
+                                "collection_type": 2,
+                                "data_type": 2,
+                                "label": "Readout signal",
+                                "name": "readout_2.result",
+                                "unit": "V"
+                            },
+                            "value": null
+                        },
+                        "result_type": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 3,
+                                "label": "Acquisition type of result",
+                                "name": "readout_2.result_type",
+                                "unit": ""
+                            },
+                            "value": "threshold"
+                        },
+                        "sampling_rate": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Sampling rate",
+                                "name": "readout_2.sampling_rate",
+                                "unit": "Sa/s"
+                            },
+                            "value": 1800000000.0
+                        }
+                    },
+                    "subtrees": {}
+                }
+            }
+        },
+        "QB3": {
+            "name": "QB3",
+            "settings": {},
+            "subtrees": {
+                "drive": {
+                    "name": "drive_3",
+                    "settings": {},
+                    "subtrees": {
+                        "awg": {
+                            "name": "drive_3.awg",
+                            "settings": {
+                                "continuous_wave_amplitude": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Continuous sine output amplitude",
+                                        "name": "drive_3.awg.continuous_wave_amplitude",
+                                        "unit": ""
+                                    },
+                                    "value": 0
+                                },
+                                "continuous_wave_enabled": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Continuous wave mode",
+                                        "name": "drive_3.awg.continuous_wave_enabled",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "dac_downsampling_factor": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "DAC downsampling factor",
+                                        "name": "drive_3.awg.dac_downsampling_factor",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "dac_rate": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "DAC rate",
+                                        "name": "drive_3.awg.dac_rate",
+                                        "unit": "Hz"
+                                    },
+                                    "value": null
+                                },
+                                "end_delay": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Delay after pulse",
+                                        "name": "drive_3.awg.end_delay",
+                                        "unit": "s"
+                                    },
+                                    "value": 0
+                                },
+                                "full_routing_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Full routing mode",
+                                        "name": "drive_3.awg.full_routing_mode",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "is_master": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Is trigger master",
+                                        "name": "drive_3.awg.is_master",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "max_output": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output ranges",
+                                        "name": "drive_3.awg.max_output",
+                                        "unit": "V"
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_0_gains_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 0 gain 0",
+                                        "name": "drive_3.awg.outputs_0_gains_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_0_gains_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 0 gain 1",
+                                        "name": "drive_3.awg.outputs_0_gains_1",
+                                        "unit": ""
+                                    },
+                                    "value": -1.0
+                                },
+                                "outputs_0_modulation_carrier_0_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 0 oscillator",
+                                        "name": "drive_3.awg.outputs_0_modulation_carrier_0_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_0_modulation_carrier_0_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 0 phase",
+                                        "name": "drive_3.awg.outputs_0_modulation_carrier_0_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": 0
+                                },
+                                "outputs_0_modulation_carrier_1_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 1 oscillator",
+                                        "name": "drive_3.awg.outputs_0_modulation_carrier_1_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_0_modulation_carrier_1_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 1 phase",
+                                        "name": "drive_3.awg.outputs_0_modulation_carrier_1_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": -90
+                                },
+                                "outputs_0_modulation_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG output 0 modulation mode",
+                                        "name": "drive_3.awg.outputs_0_modulation_mode",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "outputs_1_gains_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 1 gain 0",
+                                        "name": "drive_3.awg.outputs_1_gains_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_1_gains_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 1 gain 1",
+                                        "name": "drive_3.awg.outputs_1_gains_1",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_1_modulation_carrier_0_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 0 oscillator",
+                                        "name": "drive_3.awg.outputs_1_modulation_carrier_0_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_1_modulation_carrier_0_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 0 phase",
+                                        "name": "drive_3.awg.outputs_1_modulation_carrier_0_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": 0
+                                },
+                                "outputs_1_modulation_carrier_1_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 1 oscillator",
+                                        "name": "drive_3.awg.outputs_1_modulation_carrier_1_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_1_modulation_carrier_1_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 1 phase",
+                                        "name": "drive_3.awg.outputs_1_modulation_carrier_1_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": -90
+                                },
+                                "outputs_1_modulation_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG output 1 modulation mode",
+                                        "name": "drive_3.awg.outputs_1_modulation_mode",
+                                        "unit": ""
+                                    },
+                                    "value": 2
+                                },
+                                "phase_sensitive_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Phase sensitive mode",
+                                        "name": "drive_3.awg.phase_sensitive_mode",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                },
+                                "phase_shift_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 0 phase",
+                                        "name": "drive_3.awg.phase_shift_0",
+                                        "unit": "rad"
+                                    },
+                                    "value": 0
+                                },
+                                "phase_shift_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 1 phase",
+                                        "name": "drive_3.awg.phase_shift_1",
+                                        "unit": "rad"
+                                    },
+                                    "value": -1.5707963267948966
+                                },
+                                "playlist_repeats": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Number of repetitions",
+                                        "name": "drive_3.awg.playlist_repeats",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "sigouts_0_offset": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output 0 offset",
+                                        "name": "drive_3.awg.sigouts_0_offset",
+                                        "unit": "V"
+                                    },
+                                    "value": 0
+                                },
+                                "sigouts_1_offset": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output 1 offset",
+                                        "name": "drive_3.awg.sigouts_1_offset",
+                                        "unit": "V"
+                                    },
+                                    "value": 0
+                                },
+                                "sines_0_amplitudes_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 0 amplitude to wave output 0",
+                                        "name": "drive_3.awg.sines_0_amplitudes_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "sines_1_amplitudes_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 1 amplitude to wave output 1",
+                                        "name": "drive_3.awg.sines_1_amplitudes_1",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "status": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Output enabled",
+                                        "name": "drive_3.awg.status",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                },
+                                "trigger_delay": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Delay between trigger output and pulse",
+                                        "name": "drive_3.awg.trigger_delay",
+                                        "unit": "s"
+                                    },
+                                    "value": 0
+                                },
+                                "trigger_source": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Source of digital trigger",
+                                        "name": "drive_3.awg.trigger_source",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                }
+                            },
+                            "subtrees": {}
+                        },
+                        "local_oscillator": {
+                            "name": "drive_3.local_oscillator",
+                            "settings": {
+                                "frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "LO frequency",
+                                        "name": "drive_3.local_oscillator.frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": null
+                                },
+                                "phase": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Phase",
+                                        "name": "drive_3.local_oscillator.phase",
+                                        "unit": "deg"
+                                    },
+                                    "value": null
+                                },
+                                "power": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Power",
+                                        "name": "drive_3.local_oscillator.power",
+                                        "unit": "dBm"
+                                    },
+                                    "value": 13
+                                },
+                                "status": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "RF output enabled",
+                                        "name": "drive_3.local_oscillator.status",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                }
+                            },
+                            "subtrees": {}
+                        },
+                        "pi_pulse": {
+                            "name": "drive_3.pi_pulse",
+                            "settings": {},
+                            "subtrees": {
+                                "channel_0": {
+                                    "name": "drive_3.pi_pulse.channel_0",
+                                    "settings": {
+                                        "amplitude": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": [
+                                                    1,
+                                                    2
+                                                ],
+                                                "label": "Pulse Amplitude",
+                                                "name": "drive_3.pi_pulse.channel_0.amplitude",
+                                                "unit": ""
+                                            },
+                                            "value": 1.0
+                                        },
+                                        "csv_dir": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse CSV Directory",
+                                                "name": "drive_3.pi_pulse.channel_0.csv_dir",
+                                                "unit": ""
+                                            },
+                                            "value": null
+                                        },
+                                        "duration": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Duration",
+                                                "name": "drive_3.pi_pulse.channel_0.duration",
+                                                "unit": "s"
+                                            },
+                                            "value": 1e-07
+                                        },
+                                        "duration_type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Duration Type",
+                                                "name": "drive_3.pi_pulse.channel_0.duration_type",
+                                                "unit": ""
+                                            },
+                                            "value": "TIME"
+                                        },
+                                        "phase": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Phase",
+                                                "name": "drive_3.pi_pulse.channel_0.phase",
+                                                "unit": "rad"
+                                            },
+                                            "value": 0.0
+                                        },
+                                        "program_mode": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Program Mode",
+                                                "name": "drive_3.pi_pulse.channel_0.program_mode",
+                                                "unit": ""
+                                            },
+                                            "value": "PREDEFINED"
+                                        },
+                                        "sampling_rate": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Sample Rate",
+                                                "name": "drive_3.pi_pulse.channel_0.sample_rate",
+                                                "unit": "Hz"
+                                            },
+                                            "value": 2400000000
+                                        },
+                                        "type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Type",
+                                                "name": "drive_3.pi_pulse.channel_0.type",
+                                                "unit": ""
+                                            },
+                                            "value": "GaussianPulse"
+                                        },
+                                        "width": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Width",
+                                                "name": "drive_3.pi_pulse.channel_0.width",
+                                                "unit": "sec"
+                                            },
+                                            "value": 2.5e-08
+                                        }
+                                    },
+                                    "subtrees": {}
+                                },
+                                "channel_1": {
+                                    "name": "drive_3.pi_pulse.channel_1",
+                                    "settings": {
+                                        "amplitude": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": [
+                                                    1,
+                                                    2
+                                                ],
+                                                "label": "Pulse Amplitude",
+                                                "name": "drive_3.pi_pulse.channel_1.amplitude",
+                                                "unit": ""
+                                            },
+                                            "value": 0.0
+                                        },
+                                        "csv_dir": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse CSV Directory",
+                                                "name": "drive_3.pi_pulse.channel_1.csv_dir",
+                                                "unit": ""
+                                            },
+                                            "value": null
+                                        },
+                                        "duration": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Duration",
+                                                "name": "drive_3.pi_pulse.channel_1.duration",
+                                                "unit": "s"
+                                            },
+                                            "value": 1e-07
+                                        },
+                                        "duration_type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Duration Type",
+                                                "name": "drive_3.pi_pulse.channel_1.duration_type",
+                                                "unit": ""
+                                            },
+                                            "value": "TIME"
+                                        },
+                                        "phase": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Phase",
+                                                "name": "drive_3.pi_pulse.channel_1.phase",
+                                                "unit": "rad"
+                                            },
+                                            "value": 0.0
+                                        },
+                                        "program_mode": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Program Mode",
+                                                "name": "drive_3.pi_pulse.channel_1.program_mode",
+                                                "unit": ""
+                                            },
+                                            "value": "PREDEFINED"
+                                        },
+                                        "sampling_rate": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Sample Rate",
+                                                "name": "drive_3.pi_pulse.channel_1.sample_rate",
+                                                "unit": "Hz"
+                                            },
+                                            "value": 2400000000
+                                        },
+                                        "type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Type",
+                                                "name": "drive_3.pi_pulse.channel_1.type",
+                                                "unit": ""
+                                            },
+                                            "value": "GaussianDerivativePulse"
+                                        },
+                                        "width": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Width",
+                                                "name": "drive_3.pi_pulse.channel_1.width",
+                                                "unit": "sec"
+                                            },
+                                            "value": 2.5e-08
+                                        }
+                                    },
+                                    "subtrees": {}
+                                }
+                            }
+                        },
+                        "upconverter": {
+                            "name": "drive_3.upconverter",
+                            "settings": {
+                                "frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "RF frequency",
+                                        "name": "drive_3.upconverter.frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": 4417520000
+                                },
+                                "max_intermediate_frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Max IF frequency",
+                                        "name": "drive_3.upconverter.max_intermediate_frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": -300000000
+                                },
+                                "min_intermediate_frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Min IF frequency",
+                                        "name": "drive_3.upconverter.min_intermediate_frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": -300000000
+                                }
+                            },
+                            "subtrees": {}
+                        }
+                    }
+                },
+                "flux": {
+                    "name": "flux_3",
+                    "settings": {
+                        "voltage": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Gate dac1",
+                                "name": "flux_3.voltage",
+                                "unit": "V"
+                            },
+                            "value": 0
+                        }
+                    },
+                    "subtrees": {}
+                },
+                "readout": {
+                    "name": "readout_3",
+                    "settings": {
+                        "channel_pulse_amplitude": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Channel readout amplitude",
+                                "name": "readout_3.channel_pulse_amplitude",
+                                "unit": ""
+                            },
+                            "value": 0.2
+                        },
+                        "channel_pulse_ratio": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Ratio of I and Q amplitudes",
+                                "name": "readout_3.channel_pulse_ratio",
+                                "unit": ""
+                            },
+                            "value": 1
+                        },
+                        "correlation_source": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Correlation source",
+                                "name": "readout_3.correlation_source",
+                                "unit": ""
+                            },
+                            "value": null
+                        },
+                        "enabled_pulse_slots": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 4,
+                                "label": "Enabled pulse slots",
+                                "name": "readout_3.enabled_pulse_slots",
+                                "unit": ""
+                            },
+                            "value": [
+                                false,
+                                true
+                            ]
+                        },
+                        "frequency": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "RF frequency",
+                                "name": "readout_3.frequency",
+                                "unit": "Hz"
+                            },
+                            "value": 6208000000
+                        },
+                        "integration_threshold": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Integration threshold",
+                                "name": "readout_3.integration_threshold",
+                                "unit": ""
+                            },
+                            "value": 0.5
+                        },
+                        "integration_weights_I": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 1,
+                                "label": "Integration weights I",
+                                "name": "readout_3.integration_weights_I",
+                                "unit": ""
+                            },
+                            "value": null
+                        },
+                        "integration_weights_Q": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 1,
+                                "label": "Integration weights Q",
+                                "name": "readout_3.integration_weights_Q",
+                                "unit": ""
+                            },
+                            "value": null
+                        },
+                        "integrator_channels": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 1,
+                                "label": "Source channel indices",
+                                "name": "readout_3.integrator_channels",
+                                "unit": ""
+                            },
+                            "value": []
+                        },
+                        "intermediate_frequency": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "IF frequency",
+                                "name": "readout_3.intermediate_frequency",
+                                "unit": "Hz"
+                            },
+                            "value": 200000000
+                        },
+                        "modulate_weights": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 4,
+                                "label": "Modulate weights",
+                                "name": "readout_3.modulate_weights",
+                                "unit": ""
+                            },
+                            "value": true
+                        },
+                        "phase": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Readout pulse phase",
+                                "name": "readout_3.phase",
+                                "unit": "rad"
+                            },
+                            "value": 0
+                        },
+                        "pulse_length": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Readout pulse duration",
+                                "name": "readout_3.pulse_length",
+                                "unit": "s"
+                            },
+                            "value": 2e-06
+                        },
+                        "result": {
+                            "parameter": {
+                                "collection_type": 2,
+                                "data_type": 2,
+                                "label": "Readout signal",
+                                "name": "readout_3.result",
+                                "unit": "V"
+                            },
+                            "value": null
+                        },
+                        "result_type": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 3,
+                                "label": "Acquisition type of result",
+                                "name": "readout_3.result_type",
+                                "unit": ""
+                            },
+                            "value": "threshold"
+                        },
+                        "sampling_rate": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Sampling rate",
+                                "name": "readout_3.sampling_rate",
+                                "unit": "Sa/s"
+                            },
+                            "value": 1800000000.0
+                        }
+                    },
+                    "subtrees": {}
+                }
+            }
+        },
+        "QB4": {
+            "name": "QB4",
+            "settings": {},
+            "subtrees": {
+                "drive": {
+                    "name": "drive_4",
+                    "settings": {},
+                    "subtrees": {
+                        "awg": {
+                            "name": "drive_4.awg",
+                            "settings": {
+                                "continuous_wave_amplitude": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Continuous sine output amplitude",
+                                        "name": "drive_4.awg.continuous_wave_amplitude",
+                                        "unit": ""
+                                    },
+                                    "value": 0
+                                },
+                                "continuous_wave_enabled": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Continuous wave mode",
+                                        "name": "drive_4.awg.continuous_wave_enabled",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "dac_downsampling_factor": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "DAC downsampling factor",
+                                        "name": "drive_4.awg.dac_downsampling_factor",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "dac_rate": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "DAC rate",
+                                        "name": "drive_4.awg.dac_rate",
+                                        "unit": "Hz"
+                                    },
+                                    "value": null
+                                },
+                                "end_delay": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Delay after pulse",
+                                        "name": "drive_4.awg.end_delay",
+                                        "unit": "s"
+                                    },
+                                    "value": 0
+                                },
+                                "full_routing_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Full routing mode",
+                                        "name": "drive_4.awg.full_routing_mode",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "is_master": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Is trigger master",
+                                        "name": "drive_4.awg.is_master",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "max_output": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output ranges",
+                                        "name": "drive_4.awg.max_output",
+                                        "unit": "V"
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_0_gains_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 0 gain 0",
+                                        "name": "drive_4.awg.outputs_0_gains_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_0_gains_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 0 gain 1",
+                                        "name": "drive_4.awg.outputs_0_gains_1",
+                                        "unit": ""
+                                    },
+                                    "value": -1.0
+                                },
+                                "outputs_0_modulation_carrier_0_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 0 oscillator",
+                                        "name": "drive_4.awg.outputs_0_modulation_carrier_0_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_0_modulation_carrier_0_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 0 phase",
+                                        "name": "drive_4.awg.outputs_0_modulation_carrier_0_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": 0
+                                },
+                                "outputs_0_modulation_carrier_1_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 1 oscillator",
+                                        "name": "drive_4.awg.outputs_0_modulation_carrier_1_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_0_modulation_carrier_1_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 1 phase",
+                                        "name": "drive_4.awg.outputs_0_modulation_carrier_1_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": -90
+                                },
+                                "outputs_0_modulation_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG output 0 modulation mode",
+                                        "name": "drive_4.awg.outputs_0_modulation_mode",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "outputs_1_gains_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 1 gain 0",
+                                        "name": "drive_4.awg.outputs_1_gains_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_1_gains_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 1 gain 1",
+                                        "name": "drive_4.awg.outputs_1_gains_1",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_1_modulation_carrier_0_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 0 oscillator",
+                                        "name": "drive_4.awg.outputs_1_modulation_carrier_0_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_1_modulation_carrier_0_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 0 phase",
+                                        "name": "drive_4.awg.outputs_1_modulation_carrier_0_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": 0
+                                },
+                                "outputs_1_modulation_carrier_1_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 1 oscillator",
+                                        "name": "drive_4.awg.outputs_1_modulation_carrier_1_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_1_modulation_carrier_1_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 1 phase",
+                                        "name": "drive_4.awg.outputs_1_modulation_carrier_1_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": -90
+                                },
+                                "outputs_1_modulation_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG output 1 modulation mode",
+                                        "name": "drive_4.awg.outputs_1_modulation_mode",
+                                        "unit": ""
+                                    },
+                                    "value": 2
+                                },
+                                "phase_sensitive_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Phase sensitive mode",
+                                        "name": "drive_4.awg.phase_sensitive_mode",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                },
+                                "phase_shift_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 0 phase",
+                                        "name": "drive_4.awg.phase_shift_0",
+                                        "unit": "rad"
+                                    },
+                                    "value": 0
+                                },
+                                "phase_shift_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 1 phase",
+                                        "name": "drive_4.awg.phase_shift_1",
+                                        "unit": "rad"
+                                    },
+                                    "value": -1.5707963267948966
+                                },
+                                "playlist_repeats": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Number of repetitions",
+                                        "name": "drive_4.awg.playlist_repeats",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "sigouts_0_offset": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output 0 offset",
+                                        "name": "drive_4.awg.sigouts_0_offset",
+                                        "unit": "V"
+                                    },
+                                    "value": 0
+                                },
+                                "sigouts_1_offset": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output 1 offset",
+                                        "name": "drive_4.awg.sigouts_1_offset",
+                                        "unit": "V"
+                                    },
+                                    "value": 0
+                                },
+                                "sines_0_amplitudes_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 0 amplitude to wave output 0",
+                                        "name": "drive_4.awg.sines_0_amplitudes_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "sines_1_amplitudes_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 1 amplitude to wave output 1",
+                                        "name": "drive_4.awg.sines_1_amplitudes_1",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "status": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Output enabled",
+                                        "name": "drive_4.awg.status",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                },
+                                "trigger_delay": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Delay between trigger output and pulse",
+                                        "name": "drive_4.awg.trigger_delay",
+                                        "unit": "s"
+                                    },
+                                    "value": 0
+                                },
+                                "trigger_source": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Source of digital trigger",
+                                        "name": "drive_4.awg.trigger_source",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                }
+                            },
+                            "subtrees": {}
+                        },
+                        "local_oscillator": {
+                            "name": "drive_4.local_oscillator",
+                            "settings": {
+                                "frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "LO frequency",
+                                        "name": "drive_4.local_oscillator.frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": null
+                                },
+                                "phase": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Phase",
+                                        "name": "drive_4.local_oscillator.phase",
+                                        "unit": "deg"
+                                    },
+                                    "value": null
+                                },
+                                "power": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Power",
+                                        "name": "drive_4.local_oscillator.power",
+                                        "unit": "dBm"
+                                    },
+                                    "value": 13
+                                },
+                                "status": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "RF output enabled",
+                                        "name": "drive_4.local_oscillator.status",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                }
+                            },
+                            "subtrees": {}
+                        },
+                        "pi_pulse": {
+                            "name": "drive_4.pi_pulse",
+                            "settings": {},
+                            "subtrees": {
+                                "channel_0": {
+                                    "name": "drive_4.pi_pulse.channel_0",
+                                    "settings": {
+                                        "amplitude": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": [
+                                                    1,
+                                                    2
+                                                ],
+                                                "label": "Pulse Amplitude",
+                                                "name": "drive_4.pi_pulse.channel_0.amplitude",
+                                                "unit": ""
+                                            },
+                                            "value": 1.0
+                                        },
+                                        "csv_dir": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse CSV Directory",
+                                                "name": "drive_4.pi_pulse.channel_0.csv_dir",
+                                                "unit": ""
+                                            },
+                                            "value": null
+                                        },
+                                        "duration": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Duration",
+                                                "name": "drive_4.pi_pulse.channel_0.duration",
+                                                "unit": "s"
+                                            },
+                                            "value": 1e-07
+                                        },
+                                        "duration_type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Duration Type",
+                                                "name": "drive_4.pi_pulse.channel_0.duration_type",
+                                                "unit": ""
+                                            },
+                                            "value": "TIME"
+                                        },
+                                        "phase": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Phase",
+                                                "name": "drive_4.pi_pulse.channel_0.phase",
+                                                "unit": "rad"
+                                            },
+                                            "value": 0.0
+                                        },
+                                        "program_mode": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Program Mode",
+                                                "name": "drive_4.pi_pulse.channel_0.program_mode",
+                                                "unit": ""
+                                            },
+                                            "value": "PREDEFINED"
+                                        },
+                                        "sampling_rate": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Sample Rate",
+                                                "name": "drive_4.pi_pulse.channel_0.sample_rate",
+                                                "unit": "Hz"
+                                            },
+                                            "value": 2400000000
+                                        },
+                                        "type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Type",
+                                                "name": "drive_4.pi_pulse.channel_0.type",
+                                                "unit": ""
+                                            },
+                                            "value": "GaussianPulse"
+                                        },
+                                        "width": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Width",
+                                                "name": "drive_4.pi_pulse.channel_0.width",
+                                                "unit": "sec"
+                                            },
+                                            "value": 2.5e-08
+                                        }
+                                    },
+                                    "subtrees": {}
+                                },
+                                "channel_1": {
+                                    "name": "drive_4.pi_pulse.channel_1",
+                                    "settings": {
+                                        "amplitude": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": [
+                                                    1,
+                                                    2
+                                                ],
+                                                "label": "Pulse Amplitude",
+                                                "name": "drive_4.pi_pulse.channel_1.amplitude",
+                                                "unit": ""
+                                            },
+                                            "value": 0.0
+                                        },
+                                        "csv_dir": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse CSV Directory",
+                                                "name": "drive_4.pi_pulse.channel_1.csv_dir",
+                                                "unit": ""
+                                            },
+                                            "value": null
+                                        },
+                                        "duration": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Duration",
+                                                "name": "drive_4.pi_pulse.channel_1.duration",
+                                                "unit": "s"
+                                            },
+                                            "value": 1e-07
+                                        },
+                                        "duration_type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Duration Type",
+                                                "name": "drive_4.pi_pulse.channel_1.duration_type",
+                                                "unit": ""
+                                            },
+                                            "value": "TIME"
+                                        },
+                                        "phase": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Phase",
+                                                "name": "drive_4.pi_pulse.channel_1.phase",
+                                                "unit": "rad"
+                                            },
+                                            "value": 0.0
+                                        },
+                                        "program_mode": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Program Mode",
+                                                "name": "drive_4.pi_pulse.channel_1.program_mode",
+                                                "unit": ""
+                                            },
+                                            "value": "PREDEFINED"
+                                        },
+                                        "sampling_rate": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Sample Rate",
+                                                "name": "drive_4.pi_pulse.channel_1.sample_rate",
+                                                "unit": "Hz"
+                                            },
+                                            "value": 2400000000
+                                        },
+                                        "type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Type",
+                                                "name": "drive_4.pi_pulse.channel_1.type",
+                                                "unit": ""
+                                            },
+                                            "value": "GaussianDerivativePulse"
+                                        },
+                                        "width": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Width",
+                                                "name": "drive_4.pi_pulse.channel_1.width",
+                                                "unit": "sec"
+                                            },
+                                            "value": 2.5e-08
+                                        }
+                                    },
+                                    "subtrees": {}
+                                }
+                            }
+                        },
+                        "upconverter": {
+                            "name": "drive_4.upconverter",
+                            "settings": {
+                                "frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "RF frequency",
+                                        "name": "drive_4.upconverter.frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": 4237000000
+                                },
+                                "max_intermediate_frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Max IF frequency",
+                                        "name": "drive_4.upconverter.max_intermediate_frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": -300000000
+                                },
+                                "min_intermediate_frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Min IF frequency",
+                                        "name": "drive_4.upconverter.min_intermediate_frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": -300000000
+                                }
+                            },
+                            "subtrees": {}
+                        }
+                    }
+                },
+                "flux": {
+                    "name": "flux_4",
+                    "settings": {
+                        "voltage": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Gate dac1",
+                                "name": "flux_4.voltage",
+                                "unit": "V"
+                            },
+                            "value": 0
+                        }
+                    },
+                    "subtrees": {}
+                },
+                "readout": {
+                    "name": "readout_4",
+                    "settings": {
+                        "channel_pulse_amplitude": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Channel readout amplitude",
+                                "name": "readout_4.channel_pulse_amplitude",
+                                "unit": ""
+                            },
+                            "value": 0.2
+                        },
+                        "channel_pulse_ratio": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Ratio of I and Q amplitudes",
+                                "name": "readout_4.channel_pulse_ratio",
+                                "unit": ""
+                            },
+                            "value": 1
+                        },
+                        "correlation_source": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Correlation source",
+                                "name": "readout_4.correlation_source",
+                                "unit": ""
+                            },
+                            "value": null
+                        },
+                        "enabled_pulse_slots": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 4,
+                                "label": "Enabled pulse slots",
+                                "name": "readout_4.enabled_pulse_slots",
+                                "unit": ""
+                            },
+                            "value": [
+                                false,
+                                true
+                            ]
+                        },
+                        "frequency": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "RF frequency",
+                                "name": "readout_4.frequency",
+                                "unit": "Hz"
+                            },
+                            "value": 5923000000
+                        },
+                        "integration_threshold": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Integration threshold",
+                                "name": "readout_4.integration_threshold",
+                                "unit": ""
+                            },
+                            "value": 0.5
+                        },
+                        "integration_weights_I": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 1,
+                                "label": "Integration weights I",
+                                "name": "readout_4.integration_weights_I",
+                                "unit": ""
+                            },
+                            "value": null
+                        },
+                        "integration_weights_Q": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 1,
+                                "label": "Integration weights Q",
+                                "name": "readout_4.integration_weights_Q",
+                                "unit": ""
+                            },
+                            "value": null
+                        },
+                        "integrator_channels": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 1,
+                                "label": "Source channel indices",
+                                "name": "readout_4.integrator_channels",
+                                "unit": ""
+                            },
+                            "value": []
+                        },
+                        "intermediate_frequency": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "IF frequency",
+                                "name": "readout_4.intermediate_frequency",
+                                "unit": "Hz"
+                            },
+                            "value": 200000000
+                        },
+                        "modulate_weights": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 4,
+                                "label": "Modulate weights",
+                                "name": "readout_4.modulate_weights",
+                                "unit": ""
+                            },
+                            "value": true
+                        },
+                        "phase": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Readout pulse phase",
+                                "name": "readout_4.phase",
+                                "unit": "rad"
+                            },
+                            "value": 0
+                        },
+                        "pulse_length": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Readout pulse duration",
+                                "name": "readout_4.pulse_length",
+                                "unit": "s"
+                            },
+                            "value": 2e-06
+                        },
+                        "result": {
+                            "parameter": {
+                                "collection_type": 2,
+                                "data_type": 2,
+                                "label": "Readout signal",
+                                "name": "readout_4.result",
+                                "unit": "V"
+                            },
+                            "value": null
+                        },
+                        "result_type": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 3,
+                                "label": "Acquisition type of result",
+                                "name": "readout_4.result_type",
+                                "unit": ""
+                            },
+                            "value": "threshold"
+                        },
+                        "sampling_rate": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Sampling rate",
+                                "name": "readout_4.sampling_rate",
+                                "unit": "Sa/s"
+                            },
+                            "value": 1800000000.0
+                        }
+                    },
+                    "subtrees": {}
+                }
+            }
+        },
+        "QB5": {
+            "name": "QB5",
+            "settings": {},
+            "subtrees": {
+                "drive": {
+                    "name": "drive_5",
+                    "settings": {},
+                    "subtrees": {
+                        "awg": {
+                            "name": "drive_5.awg",
+                            "settings": {
+                                "continuous_wave_amplitude": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Continuous sine output amplitude",
+                                        "name": "drive_5.awg.continuous_wave_amplitude",
+                                        "unit": ""
+                                    },
+                                    "value": 0
+                                },
+                                "continuous_wave_enabled": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Continuous wave mode",
+                                        "name": "drive_5.awg.continuous_wave_enabled",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "dac_downsampling_factor": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "DAC downsampling factor",
+                                        "name": "drive_5.awg.dac_downsampling_factor",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "dac_rate": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "DAC rate",
+                                        "name": "drive_5.awg.dac_rate",
+                                        "unit": "Hz"
+                                    },
+                                    "value": null
+                                },
+                                "end_delay": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Delay after pulse",
+                                        "name": "drive_5.awg.end_delay",
+                                        "unit": "s"
+                                    },
+                                    "value": 0
+                                },
+                                "full_routing_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Full routing mode",
+                                        "name": "drive_5.awg.full_routing_mode",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "is_master": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Is trigger master",
+                                        "name": "drive_5.awg.is_master",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "max_output": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output ranges",
+                                        "name": "drive_5.awg.max_output",
+                                        "unit": "V"
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_0_gains_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 0 gain 0",
+                                        "name": "drive_5.awg.outputs_0_gains_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_0_gains_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 0 gain 1",
+                                        "name": "drive_5.awg.outputs_0_gains_1",
+                                        "unit": ""
+                                    },
+                                    "value": -1.0
+                                },
+                                "outputs_0_modulation_carrier_0_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 0 oscillator",
+                                        "name": "drive_5.awg.outputs_0_modulation_carrier_0_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_0_modulation_carrier_0_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 0 phase",
+                                        "name": "drive_5.awg.outputs_0_modulation_carrier_0_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": 0
+                                },
+                                "outputs_0_modulation_carrier_1_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 1 oscillator",
+                                        "name": "drive_5.awg.outputs_0_modulation_carrier_1_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_0_modulation_carrier_1_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 1 phase",
+                                        "name": "drive_5.awg.outputs_0_modulation_carrier_1_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": -90
+                                },
+                                "outputs_0_modulation_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG output 0 modulation mode",
+                                        "name": "drive_5.awg.outputs_0_modulation_mode",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "outputs_1_gains_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 1 gain 0",
+                                        "name": "drive_5.awg.outputs_1_gains_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_1_gains_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 1 gain 1",
+                                        "name": "drive_5.awg.outputs_1_gains_1",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_1_modulation_carrier_0_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 0 oscillator",
+                                        "name": "drive_5.awg.outputs_1_modulation_carrier_0_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_1_modulation_carrier_0_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 0 phase",
+                                        "name": "drive_5.awg.outputs_1_modulation_carrier_0_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": 0
+                                },
+                                "outputs_1_modulation_carrier_1_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 1 oscillator",
+                                        "name": "drive_5.awg.outputs_1_modulation_carrier_1_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_1_modulation_carrier_1_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 1 phase",
+                                        "name": "drive_5.awg.outputs_1_modulation_carrier_1_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": -90
+                                },
+                                "outputs_1_modulation_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG output 1 modulation mode",
+                                        "name": "drive_5.awg.outputs_1_modulation_mode",
+                                        "unit": ""
+                                    },
+                                    "value": 2
+                                },
+                                "phase_sensitive_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Phase sensitive mode",
+                                        "name": "drive_5.awg.phase_sensitive_mode",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                },
+                                "phase_shift_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 0 phase",
+                                        "name": "drive_5.awg.phase_shift_0",
+                                        "unit": "rad"
+                                    },
+                                    "value": 0
+                                },
+                                "phase_shift_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 1 phase",
+                                        "name": "drive_5.awg.phase_shift_1",
+                                        "unit": "rad"
+                                    },
+                                    "value": -1.5707963267948966
+                                },
+                                "playlist_repeats": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Number of repetitions",
+                                        "name": "drive_5.awg.playlist_repeats",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "sigouts_0_offset": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output 0 offset",
+                                        "name": "drive_5.awg.sigouts_0_offset",
+                                        "unit": "V"
+                                    },
+                                    "value": 0
+                                },
+                                "sigouts_1_offset": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output 1 offset",
+                                        "name": "drive_5.awg.sigouts_1_offset",
+                                        "unit": "V"
+                                    },
+                                    "value": 0
+                                },
+                                "sines_0_amplitudes_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 0 amplitude to wave output 0",
+                                        "name": "drive_5.awg.sines_0_amplitudes_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "sines_1_amplitudes_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 1 amplitude to wave output 1",
+                                        "name": "drive_5.awg.sines_1_amplitudes_1",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "status": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Output enabled",
+                                        "name": "drive_5.awg.status",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                },
+                                "trigger_delay": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Delay between trigger output and pulse",
+                                        "name": "drive_5.awg.trigger_delay",
+                                        "unit": "s"
+                                    },
+                                    "value": 0
+                                },
+                                "trigger_source": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Source of digital trigger",
+                                        "name": "drive_5.awg.trigger_source",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                }
+                            },
+                            "subtrees": {}
+                        },
+                        "local_oscillator": {
+                            "name": "drive_5.local_oscillator",
+                            "settings": {
+                                "frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "LO frequency",
+                                        "name": "drive_5.local_oscillator.frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": null
+                                },
+                                "phase": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Phase",
+                                        "name": "drive_5.local_oscillator.phase",
+                                        "unit": "deg"
+                                    },
+                                    "value": null
+                                },
+                                "power": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Power",
+                                        "name": "drive_5.local_oscillator.power",
+                                        "unit": "dBm"
+                                    },
+                                    "value": 13
+                                },
+                                "status": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "RF output enabled",
+                                        "name": "drive_5.local_oscillator.status",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                }
+                            },
+                            "subtrees": {}
+                        },
+                        "pi_pulse": {
+                            "name": "drive_5.pi_pulse",
+                            "settings": {},
+                            "subtrees": {
+                                "channel_0": {
+                                    "name": "drive_5.pi_pulse.channel_0",
+                                    "settings": {
+                                        "amplitude": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": [
+                                                    1,
+                                                    2
+                                                ],
+                                                "label": "Pulse Amplitude",
+                                                "name": "drive_5.pi_pulse.channel_0.amplitude",
+                                                "unit": ""
+                                            },
+                                            "value": 1.0
+                                        },
+                                        "csv_dir": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse CSV Directory",
+                                                "name": "drive_5.pi_pulse.channel_0.csv_dir",
+                                                "unit": ""
+                                            },
+                                            "value": null
+                                        },
+                                        "duration": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Duration",
+                                                "name": "drive_5.pi_pulse.channel_0.duration",
+                                                "unit": "s"
+                                            },
+                                            "value": 1e-07
+                                        },
+                                        "duration_type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Duration Type",
+                                                "name": "drive_5.pi_pulse.channel_0.duration_type",
+                                                "unit": ""
+                                            },
+                                            "value": "TIME"
+                                        },
+                                        "phase": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Phase",
+                                                "name": "drive_5.pi_pulse.channel_0.phase",
+                                                "unit": "rad"
+                                            },
+                                            "value": 0.0
+                                        },
+                                        "program_mode": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Program Mode",
+                                                "name": "drive_5.pi_pulse.channel_0.program_mode",
+                                                "unit": ""
+                                            },
+                                            "value": "PREDEFINED"
+                                        },
+                                        "sampling_rate": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Sample Rate",
+                                                "name": "drive_5.pi_pulse.channel_0.sample_rate",
+                                                "unit": "Hz"
+                                            },
+                                            "value": 2400000000
+                                        },
+                                        "type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Type",
+                                                "name": "drive_5.pi_pulse.channel_0.type",
+                                                "unit": ""
+                                            },
+                                            "value": "GaussianPulse"
+                                        },
+                                        "width": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Width",
+                                                "name": "drive_5.pi_pulse.channel_0.width",
+                                                "unit": "sec"
+                                            },
+                                            "value": 2.5e-08
+                                        }
+                                    },
+                                    "subtrees": {}
+                                },
+                                "channel_1": {
+                                    "name": "drive_5.pi_pulse.channel_1",
+                                    "settings": {
+                                        "amplitude": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": [
+                                                    1,
+                                                    2
+                                                ],
+                                                "label": "Pulse Amplitude",
+                                                "name": "drive_5.pi_pulse.channel_1.amplitude",
+                                                "unit": ""
+                                            },
+                                            "value": 0.0
+                                        },
+                                        "csv_dir": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse CSV Directory",
+                                                "name": "drive_5.pi_pulse.channel_1.csv_dir",
+                                                "unit": ""
+                                            },
+                                            "value": null
+                                        },
+                                        "duration": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Duration",
+                                                "name": "drive_5.pi_pulse.channel_1.duration",
+                                                "unit": "s"
+                                            },
+                                            "value": 1e-07
+                                        },
+                                        "duration_type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Duration Type",
+                                                "name": "drive_5.pi_pulse.channel_1.duration_type",
+                                                "unit": ""
+                                            },
+                                            "value": "TIME"
+                                        },
+                                        "phase": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Phase",
+                                                "name": "drive_5.pi_pulse.channel_1.phase",
+                                                "unit": "rad"
+                                            },
+                                            "value": 0.0
+                                        },
+                                        "program_mode": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Program Mode",
+                                                "name": "drive_5.pi_pulse.channel_1.program_mode",
+                                                "unit": ""
+                                            },
+                                            "value": "PREDEFINED"
+                                        },
+                                        "sampling_rate": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Sample Rate",
+                                                "name": "drive_5.pi_pulse.channel_1.sample_rate",
+                                                "unit": "Hz"
+                                            },
+                                            "value": 2400000000
+                                        },
+                                        "type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Type",
+                                                "name": "drive_5.pi_pulse.channel_1.type",
+                                                "unit": ""
+                                            },
+                                            "value": "GaussianDerivativePulse"
+                                        },
+                                        "width": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Width",
+                                                "name": "drive_5.pi_pulse.channel_1.width",
+                                                "unit": "sec"
+                                            },
+                                            "value": 2.5e-08
+                                        }
+                                    },
+                                    "subtrees": {}
+                                }
+                            }
+                        },
+                        "upconverter": {
+                            "name": "drive_5.upconverter",
+                            "settings": {
+                                "frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "RF frequency",
+                                        "name": "drive_5.upconverter.frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": 4352386300
+                                },
+                                "max_intermediate_frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Max IF frequency",
+                                        "name": "drive_5.upconverter.max_intermediate_frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": -300000000
+                                },
+                                "min_intermediate_frequency": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Min IF frequency",
+                                        "name": "drive_5.upconverter.min_intermediate_frequency",
+                                        "unit": "Hz"
+                                    },
+                                    "value": -300000000
+                                }
+                            },
+                            "subtrees": {}
+                        }
+                    }
+                },
+                "flux": {
+                    "name": "flux_5",
+                    "settings": {
+                        "voltage": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Gate dac1",
+                                "name": "flux_5.voltage",
+                                "unit": "V"
+                            },
+                            "value": -0.125
+                        }
+                    },
+                    "subtrees": {}
+                },
+                "readout": {
+                    "name": "readout_5",
+                    "settings": {
+                        "channel_pulse_amplitude": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Channel readout amplitude",
+                                "name": "readout_5.channel_pulse_amplitude",
+                                "unit": ""
+                            },
+                            "value": 0.2
+                        },
+                        "channel_pulse_ratio": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Ratio of I and Q amplitudes",
+                                "name": "readout_5.channel_pulse_ratio",
+                                "unit": ""
+                            },
+                            "value": 1
+                        },
+                        "correlation_source": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Correlation source",
+                                "name": "readout_5.correlation_source",
+                                "unit": ""
+                            },
+                            "value": null
+                        },
+                        "enabled_pulse_slots": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 4,
+                                "label": "Enabled pulse slots",
+                                "name": "readout_5.enabled_pulse_slots",
+                                "unit": ""
+                            },
+                            "value": [
+                                false,
+                                true
+                            ]
+                        },
+                        "frequency": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "RF frequency",
+                                "name": "readout_5.frequency",
+                                "unit": "Hz"
+                            },
+                            "value": 5605000000
+                        },
+                        "integration_threshold": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Integration threshold",
+                                "name": "readout_5.integration_threshold",
+                                "unit": ""
+                            },
+                            "value": 0.5
+                        },
+                        "integration_weights_I": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 1,
+                                "label": "Integration weights I",
+                                "name": "readout_5.integration_weights_I",
+                                "unit": ""
+                            },
+                            "value": null
+                        },
+                        "integration_weights_Q": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 1,
+                                "label": "Integration weights Q",
+                                "name": "readout_5.integration_weights_Q",
+                                "unit": ""
+                            },
+                            "value": null
+                        },
+                        "integrator_channels": {
+                            "parameter": {
+                                "collection_type": 1,
+                                "data_type": 1,
+                                "label": "Source channel indices",
+                                "name": "readout_5.integrator_channels",
+                                "unit": ""
+                            },
+                            "value": []
+                        },
+                        "intermediate_frequency": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "IF frequency",
+                                "name": "readout_5.intermediate_frequency",
+                                "unit": "Hz"
+                            },
+                            "value": 200000000
+                        },
+                        "modulate_weights": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 4,
+                                "label": "Modulate weights",
+                                "name": "readout_5.modulate_weights",
+                                "unit": ""
+                            },
+                            "value": true
+                        },
+                        "phase": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Readout pulse phase",
+                                "name": "readout_5.phase",
+                                "unit": "rad"
+                            },
+                            "value": 0
+                        },
+                        "pulse_length": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Readout pulse duration",
+                                "name": "readout_5.pulse_length",
+                                "unit": "s"
+                            },
+                            "value": 2e-06
+                        },
+                        "result": {
+                            "parameter": {
+                                "collection_type": 2,
+                                "data_type": 2,
+                                "label": "Readout signal",
+                                "name": "readout_5.result",
+                                "unit": "V"
+                            },
+                            "value": null
+                        },
+                        "result_type": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 3,
+                                "label": "Acquisition type of result",
+                                "name": "readout_5.result_type",
+                                "unit": ""
+                            },
+                            "value": "threshold"
+                        },
+                        "sampling_rate": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Sampling rate",
+                                "name": "readout_5.sampling_rate",
+                                "unit": "Sa/s"
+                            },
+                            "value": 1800000000.0
+                        }
+                    },
+                    "subtrees": {}
+                }
+            }
+        },
+        "TC_3_1": {
+            "name": "TC_3_1",
+            "settings": {},
+            "subtrees": {
+                "flux": {
+                    "name": "flux_TC_3_1",
+                    "settings": {
+                        "voltage": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Gate dac1",
+                                "name": "flux_TC_3_1.voltage",
+                                "unit": "V"
+                            },
+                            "value": 0.0
+                        }
+                    },
+                    "subtrees": {
+                        "awg": {
+                            "name": "flux_TC_3_1.awg",
+                            "settings": {
+                                "continuous_wave_amplitude": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Continuous sine output amplitude",
+                                        "name": "flux_TC_3_1.awg.continuous_wave_amplitude",
+                                        "unit": ""
+                                    },
+                                    "value": 0
+                                },
+                                "continuous_wave_enabled": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Continuous wave mode",
+                                        "name": "flux_TC_3_1.awg.continuous_wave_enabled",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "dac_downsampling_factor": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "DAC downsampling factor",
+                                        "name": "flux_TC_3_1.awg.dac_downsampling_factor",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "dac_rate": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "DAC rate",
+                                        "name": "flux_TC_3_1.awg.dac_rate",
+                                        "unit": "Hz"
+                                    },
+                                    "value": null
+                                },
+                                "end_delay": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Delay after pulse",
+                                        "name": "flux_TC_3_1.awg.end_delay",
+                                        "unit": "s"
+                                    },
+                                    "value": 0
+                                },
+                                "full_routing_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Full routing mode",
+                                        "name": "flux_TC_3_1.awg.full_routing_mode",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "is_master": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Is trigger master",
+                                        "name": "flux_TC_3_1.awg.is_master",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "max_output": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output ranges",
+                                        "name": "flux_TC_3_1.awg.max_output",
+                                        "unit": "V"
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_0_gains_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 0 gain 0",
+                                        "name": "flux_TC_3_1.awg.outputs_0_gains_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_0_gains_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 0 gain 1",
+                                        "name": "flux_TC_3_1.awg.outputs_0_gains_1",
+                                        "unit": ""
+                                    },
+                                    "value": -1.0
+                                },
+                                "outputs_0_modulation_carrier_0_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 0 oscillator",
+                                        "name": "flux_TC_3_1.awg.outputs_0_modulation_carrier_0_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_0_modulation_carrier_0_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 0 phase",
+                                        "name": "flux_TC_3_1.awg.outputs_0_modulation_carrier_0_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": 0
+                                },
+                                "outputs_0_modulation_carrier_1_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 1 oscillator",
+                                        "name": "flux_TC_3_1.awg.outputs_0_modulation_carrier_1_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_0_modulation_carrier_1_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 1 phase",
+                                        "name": "flux_TC_3_1.awg.outputs_0_modulation_carrier_1_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": -90
+                                },
+                                "outputs_0_modulation_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG output 0 modulation mode",
+                                        "name": "flux_TC_3_1.awg.outputs_0_modulation_mode",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "outputs_1_gains_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 1 gain 0",
+                                        "name": "flux_TC_3_1.awg.outputs_1_gains_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_1_gains_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 1 gain 1",
+                                        "name": "flux_TC_3_1.awg.outputs_1_gains_1",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_1_modulation_carrier_0_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 0 oscillator",
+                                        "name": "flux_TC_3_1.awg.outputs_1_modulation_carrier_0_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_1_modulation_carrier_0_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 0 phase",
+                                        "name": "flux_TC_3_1.awg.outputs_1_modulation_carrier_0_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": 0
+                                },
+                                "outputs_1_modulation_carrier_1_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 1 oscillator",
+                                        "name": "flux_TC_3_1.awg.outputs_1_modulation_carrier_1_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_1_modulation_carrier_1_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 1 phase",
+                                        "name": "flux_TC_3_1.awg.outputs_1_modulation_carrier_1_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": -90
+                                },
+                                "outputs_1_modulation_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG output 1 modulation mode",
+                                        "name": "flux_TC_3_1.awg.outputs_1_modulation_mode",
+                                        "unit": ""
+                                    },
+                                    "value": 2
+                                },
+                                "phase_sensitive_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Phase sensitive mode",
+                                        "name": "flux_TC_3_1.awg.phase_sensitive_mode",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                },
+                                "phase_shift_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 0 phase",
+                                        "name": "flux_TC_3_1.awg.phase_shift_0",
+                                        "unit": "rad"
+                                    },
+                                    "value": 0
+                                },
+                                "phase_shift_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 1 phase",
+                                        "name": "flux_TC_3_1.awg.phase_shift_1",
+                                        "unit": "rad"
+                                    },
+                                    "value": -1.5707963267948966
+                                },
+                                "playlist_repeats": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Number of repetitions",
+                                        "name": "flux_TC_3_1.awg.playlist_repeats",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "sigouts_0_offset": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output 0 offset",
+                                        "name": "flux_TC_3_1.awg.sigouts_0_offset",
+                                        "unit": "V"
+                                    },
+                                    "value": 0
+                                },
+                                "sigouts_1_offset": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output 1 offset",
+                                        "name": "flux_TC_3_1.awg.sigouts_1_offset",
+                                        "unit": "V"
+                                    },
+                                    "value": 0
+                                },
+                                "sines_0_amplitudes_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 0 amplitude to wave output 0",
+                                        "name": "flux_TC_3_1.awg.sines_0_amplitudes_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "sines_1_amplitudes_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 1 amplitude to wave output 1",
+                                        "name": "flux_TC_3_1.awg.sines_1_amplitudes_1",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "status": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Output enabled",
+                                        "name": "flux_TC_3_1.awg.status",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                },
+                                "trigger_delay": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Delay between trigger output and pulse",
+                                        "name": "flux_TC_3_1.awg.trigger_delay",
+                                        "unit": "s"
+                                    },
+                                    "value": 0
+                                },
+                                "trigger_source": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Source of digital trigger",
+                                        "name": "flux_TC_3_1.awg.trigger_source",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                }
+                            },
+                            "subtrees": {}
+                        },
+                        "pulse": {
+                            "name": "flux_TC_3_1.pulse",
+                            "settings": {},
+                            "subtrees": {
+                                "channel_0": {
+                                    "name": "flux_TC_3_1.pulse.channel_0",
+                                    "settings": {
+                                        "amplitude": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": [
+                                                    1,
+                                                    2
+                                                ],
+                                                "label": "Pulse Amplitude",
+                                                "name": "flux_TC_3_1.pulse.channel_0.amplitude",
+                                                "unit": ""
+                                            },
+                                            "value": 1
+                                        },
+                                        "csv_dir": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse CSV Directory",
+                                                "name": "flux_TC_3_1.pulse.channel_0.csv_dir",
+                                                "unit": ""
+                                            },
+                                            "value": null
+                                        },
+                                        "duration": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Duration",
+                                                "name": "flux_TC_3_1.pulse.channel_0.duration",
+                                                "unit": "s"
+                                            },
+                                            "value": 1.1e-07
+                                        },
+                                        "duration_type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Duration Type",
+                                                "name": "flux_TC_3_1.pulse.channel_0.duration_type",
+                                                "unit": ""
+                                            },
+                                            "value": "TIME"
+                                        },
+                                        "filter_width": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Filter width",
+                                                "name": "flux_TC_3_1.pulse.channel_0.filter_width",
+                                                "unit": "s"
+                                            },
+                                            "value": 1e-08
+                                        },
+                                        "phase": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Phase",
+                                                "name": "flux_TC_3_1.pulse.channel_0.phase",
+                                                "unit": "rad"
+                                            },
+                                            "value": 0.0
+                                        },
+                                        "program_mode": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Program Mode",
+                                                "name": "flux_TC_3_1.pulse.channel_0.program_mode",
+                                                "unit": ""
+                                            },
+                                            "value": "PREDEFINED"
+                                        },
+                                        "rectangle_width": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Width",
+                                                "name": "flux_TC_3_1.pulse.channel_0.rectangle_width",
+                                                "unit": "s"
+                                            },
+                                            "value": 1e-07
+                                        },
+                                        "sampling_rate": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Sample Rate",
+                                                "name": "flux_TC_3_1.pulse.channel_0.sample_rate",
+                                                "unit": "Hz"
+                                            },
+                                            "value": 2400000000.0
+                                        },
+                                        "type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Type",
+                                                "name": "flux_TC_3_1.pulse.channel_0.type",
+                                                "unit": ""
+                                            },
+                                            "value": "ErfSquarePulse"
+                                        }
+                                    },
+                                    "subtrees": {}
+                                }
+                            }
+                        },
+                        "rz_angles": {
+                            "name": "rz_angles",
+                            "settings": {},
+                            "subtrees": {}
+                        }
+                    }
+                }
+            }
+        },
+        "TC_3_2": {
+            "name": "TC_3_2",
+            "settings": {},
+            "subtrees": {
+                "flux": {
+                    "name": "flux_TC_3_2",
+                    "settings": {
+                        "voltage": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Gate dac1",
+                                "name": "flux_TC_3_2.voltage",
+                                "unit": "V"
+                            },
+                            "value": 0.0
+                        }
+                    },
+                    "subtrees": {
+                        "awg": {
+                            "name": "flux_TC_3_2.awg",
+                            "settings": {
+                                "continuous_wave_amplitude": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Continuous sine output amplitude",
+                                        "name": "flux_TC_3_2.awg.continuous_wave_amplitude",
+                                        "unit": ""
+                                    },
+                                    "value": 0
+                                },
+                                "continuous_wave_enabled": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Continuous wave mode",
+                                        "name": "flux_TC_3_2.awg.continuous_wave_enabled",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "dac_downsampling_factor": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "DAC downsampling factor",
+                                        "name": "flux_TC_3_2.awg.dac_downsampling_factor",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "dac_rate": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "DAC rate",
+                                        "name": "flux_TC_3_2.awg.dac_rate",
+                                        "unit": "Hz"
+                                    },
+                                    "value": null
+                                },
+                                "end_delay": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Delay after pulse",
+                                        "name": "flux_TC_3_2.awg.end_delay",
+                                        "unit": "s"
+                                    },
+                                    "value": 0
+                                },
+                                "full_routing_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Full routing mode",
+                                        "name": "flux_TC_3_2.awg.full_routing_mode",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "is_master": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Is trigger master",
+                                        "name": "flux_TC_3_2.awg.is_master",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "max_output": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output ranges",
+                                        "name": "flux_TC_3_2.awg.max_output",
+                                        "unit": "V"
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_0_gains_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 0 gain 0",
+                                        "name": "flux_TC_3_2.awg.outputs_0_gains_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_0_gains_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 0 gain 1",
+                                        "name": "flux_TC_3_2.awg.outputs_0_gains_1",
+                                        "unit": ""
+                                    },
+                                    "value": -1.0
+                                },
+                                "outputs_0_modulation_carrier_0_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 0 oscillator",
+                                        "name": "flux_TC_3_2.awg.outputs_0_modulation_carrier_0_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_0_modulation_carrier_0_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 0 phase",
+                                        "name": "flux_TC_3_2.awg.outputs_0_modulation_carrier_0_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": 0
+                                },
+                                "outputs_0_modulation_carrier_1_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 1 oscillator",
+                                        "name": "flux_TC_3_2.awg.outputs_0_modulation_carrier_1_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_0_modulation_carrier_1_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 1 phase",
+                                        "name": "flux_TC_3_2.awg.outputs_0_modulation_carrier_1_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": -90
+                                },
+                                "outputs_0_modulation_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG output 0 modulation mode",
+                                        "name": "flux_TC_3_2.awg.outputs_0_modulation_mode",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "outputs_1_gains_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 1 gain 0",
+                                        "name": "flux_TC_3_2.awg.outputs_1_gains_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_1_gains_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 1 gain 1",
+                                        "name": "flux_TC_3_2.awg.outputs_1_gains_1",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_1_modulation_carrier_0_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 0 oscillator",
+                                        "name": "flux_TC_3_2.awg.outputs_1_modulation_carrier_0_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_1_modulation_carrier_0_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 0 phase",
+                                        "name": "flux_TC_3_2.awg.outputs_1_modulation_carrier_0_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": 0
+                                },
+                                "outputs_1_modulation_carrier_1_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 1 oscillator",
+                                        "name": "flux_TC_3_2.awg.outputs_1_modulation_carrier_1_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_1_modulation_carrier_1_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 1 phase",
+                                        "name": "flux_TC_3_2.awg.outputs_1_modulation_carrier_1_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": -90
+                                },
+                                "outputs_1_modulation_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG output 1 modulation mode",
+                                        "name": "flux_TC_3_2.awg.outputs_1_modulation_mode",
+                                        "unit": ""
+                                    },
+                                    "value": 2
+                                },
+                                "phase_sensitive_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Phase sensitive mode",
+                                        "name": "flux_TC_3_2.awg.phase_sensitive_mode",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                },
+                                "phase_shift_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 0 phase",
+                                        "name": "flux_TC_3_2.awg.phase_shift_0",
+                                        "unit": "rad"
+                                    },
+                                    "value": 0
+                                },
+                                "phase_shift_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 1 phase",
+                                        "name": "flux_TC_3_2.awg.phase_shift_1",
+                                        "unit": "rad"
+                                    },
+                                    "value": -1.5707963267948966
+                                },
+                                "playlist_repeats": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Number of repetitions",
+                                        "name": "flux_TC_3_2.awg.playlist_repeats",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "sigouts_0_offset": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output 0 offset",
+                                        "name": "flux_TC_3_2.awg.sigouts_0_offset",
+                                        "unit": "V"
+                                    },
+                                    "value": 0
+                                },
+                                "sigouts_1_offset": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output 1 offset",
+                                        "name": "flux_TC_3_2.awg.sigouts_1_offset",
+                                        "unit": "V"
+                                    },
+                                    "value": 0
+                                },
+                                "sines_0_amplitudes_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 0 amplitude to wave output 0",
+                                        "name": "flux_TC_3_2.awg.sines_0_amplitudes_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "sines_1_amplitudes_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 1 amplitude to wave output 1",
+                                        "name": "flux_TC_3_2.awg.sines_1_amplitudes_1",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "status": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Output enabled",
+                                        "name": "flux_TC_3_2.awg.status",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                },
+                                "trigger_delay": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Delay between trigger output and pulse",
+                                        "name": "flux_TC_3_2.awg.trigger_delay",
+                                        "unit": "s"
+                                    },
+                                    "value": 0
+                                },
+                                "trigger_source": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Source of digital trigger",
+                                        "name": "flux_TC_3_2.awg.trigger_source",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                }
+                            },
+                            "subtrees": {}
+                        },
+                        "pulse": {
+                            "name": "flux_TC_3_2.pulse",
+                            "settings": {},
+                            "subtrees": {
+                                "channel_0": {
+                                    "name": "flux_TC_3_2.pulse.channel_0",
+                                    "settings": {
+                                        "amplitude": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": [
+                                                    1,
+                                                    2
+                                                ],
+                                                "label": "Pulse Amplitude",
+                                                "name": "flux_TC_3_2.pulse.channel_0.amplitude",
+                                                "unit": ""
+                                            },
+                                            "value": 1
+                                        },
+                                        "csv_dir": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse CSV Directory",
+                                                "name": "flux_TC_3_2.pulse.channel_0.csv_dir",
+                                                "unit": ""
+                                            },
+                                            "value": null
+                                        },
+                                        "duration": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Duration",
+                                                "name": "flux_TC_3_2.pulse.channel_0.duration",
+                                                "unit": "s"
+                                            },
+                                            "value": 1.1e-07
+                                        },
+                                        "duration_type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Duration Type",
+                                                "name": "flux_TC_3_2.pulse.channel_0.duration_type",
+                                                "unit": ""
+                                            },
+                                            "value": "TIME"
+                                        },
+                                        "filter_width": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Filter width",
+                                                "name": "flux_TC_3_2.pulse.channel_0.filter_width",
+                                                "unit": "s"
+                                            },
+                                            "value": 1e-08
+                                        },
+                                        "phase": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Phase",
+                                                "name": "flux_TC_3_2.pulse.channel_0.phase",
+                                                "unit": "rad"
+                                            },
+                                            "value": 0.0
+                                        },
+                                        "program_mode": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Program Mode",
+                                                "name": "flux_TC_3_2.pulse.channel_0.program_mode",
+                                                "unit": ""
+                                            },
+                                            "value": "PREDEFINED"
+                                        },
+                                        "rectangle_width": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Width",
+                                                "name": "flux_TC_3_2.pulse.channel_0.rectangle_width",
+                                                "unit": "s"
+                                            },
+                                            "value": 1e-07
+                                        },
+                                        "sampling_rate": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Sample Rate",
+                                                "name": "flux_TC_3_2.pulse.channel_0.sample_rate",
+                                                "unit": "Hz"
+                                            },
+                                            "value": 2400000000.0
+                                        },
+                                        "type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Type",
+                                                "name": "flux_TC_3_2.pulse.channel_0.type",
+                                                "unit": ""
+                                            },
+                                            "value": "ErfSquarePulse"
+                                        }
+                                    },
+                                    "subtrees": {}
+                                }
+                            }
+                        },
+                        "rz_angles": {
+                            "name": "rz_angles",
+                            "settings": {},
+                            "subtrees": {}
+                        }
+                    }
+                }
+            }
+        },
+        "TC_3_4": {
+            "name": "TC_3_4",
+            "settings": {},
+            "subtrees": {
+                "flux": {
+                    "name": "flux_TC_3_4",
+                    "settings": {
+                        "voltage": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Gate dac1",
+                                "name": "flux_TC_3_4.voltage",
+                                "unit": "V"
+                            },
+                            "value": 0.0
+                        }
+                    },
+                    "subtrees": {
+                        "awg": {
+                            "name": "flux_TC_3_4.awg",
+                            "settings": {
+                                "continuous_wave_amplitude": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Continuous sine output amplitude",
+                                        "name": "flux_TC_3_4.awg.continuous_wave_amplitude",
+                                        "unit": ""
+                                    },
+                                    "value": 0
+                                },
+                                "continuous_wave_enabled": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Continuous wave mode",
+                                        "name": "flux_TC_3_4.awg.continuous_wave_enabled",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "dac_downsampling_factor": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "DAC downsampling factor",
+                                        "name": "flux_TC_3_4.awg.dac_downsampling_factor",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "dac_rate": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "DAC rate",
+                                        "name": "flux_TC_3_4.awg.dac_rate",
+                                        "unit": "Hz"
+                                    },
+                                    "value": null
+                                },
+                                "end_delay": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Delay after pulse",
+                                        "name": "flux_TC_3_4.awg.end_delay",
+                                        "unit": "s"
+                                    },
+                                    "value": 0
+                                },
+                                "full_routing_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Full routing mode",
+                                        "name": "flux_TC_3_4.awg.full_routing_mode",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "is_master": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Is trigger master",
+                                        "name": "flux_TC_3_4.awg.is_master",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "max_output": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output ranges",
+                                        "name": "flux_TC_3_4.awg.max_output",
+                                        "unit": "V"
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_0_gains_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 0 gain 0",
+                                        "name": "flux_TC_3_4.awg.outputs_0_gains_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_0_gains_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 0 gain 1",
+                                        "name": "flux_TC_3_4.awg.outputs_0_gains_1",
+                                        "unit": ""
+                                    },
+                                    "value": -1.0
+                                },
+                                "outputs_0_modulation_carrier_0_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 0 oscillator",
+                                        "name": "flux_TC_3_4.awg.outputs_0_modulation_carrier_0_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_0_modulation_carrier_0_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 0 phase",
+                                        "name": "flux_TC_3_4.awg.outputs_0_modulation_carrier_0_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": 0
+                                },
+                                "outputs_0_modulation_carrier_1_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 1 oscillator",
+                                        "name": "flux_TC_3_4.awg.outputs_0_modulation_carrier_1_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_0_modulation_carrier_1_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 1 phase",
+                                        "name": "flux_TC_3_4.awg.outputs_0_modulation_carrier_1_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": -90
+                                },
+                                "outputs_0_modulation_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG output 0 modulation mode",
+                                        "name": "flux_TC_3_4.awg.outputs_0_modulation_mode",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "outputs_1_gains_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 1 gain 0",
+                                        "name": "flux_TC_3_4.awg.outputs_1_gains_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_1_gains_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 1 gain 1",
+                                        "name": "flux_TC_3_4.awg.outputs_1_gains_1",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_1_modulation_carrier_0_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 0 oscillator",
+                                        "name": "flux_TC_3_4.awg.outputs_1_modulation_carrier_0_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_1_modulation_carrier_0_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 0 phase",
+                                        "name": "flux_TC_3_4.awg.outputs_1_modulation_carrier_0_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": 0
+                                },
+                                "outputs_1_modulation_carrier_1_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 1 oscillator",
+                                        "name": "flux_TC_3_4.awg.outputs_1_modulation_carrier_1_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_1_modulation_carrier_1_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 1 phase",
+                                        "name": "flux_TC_3_4.awg.outputs_1_modulation_carrier_1_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": -90
+                                },
+                                "outputs_1_modulation_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG output 1 modulation mode",
+                                        "name": "flux_TC_3_4.awg.outputs_1_modulation_mode",
+                                        "unit": ""
+                                    },
+                                    "value": 2
+                                },
+                                "phase_sensitive_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Phase sensitive mode",
+                                        "name": "flux_TC_3_4.awg.phase_sensitive_mode",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                },
+                                "phase_shift_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 0 phase",
+                                        "name": "flux_TC_3_4.awg.phase_shift_0",
+                                        "unit": "rad"
+                                    },
+                                    "value": 0
+                                },
+                                "phase_shift_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 1 phase",
+                                        "name": "flux_TC_3_4.awg.phase_shift_1",
+                                        "unit": "rad"
+                                    },
+                                    "value": -1.5707963267948966
+                                },
+                                "playlist_repeats": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Number of repetitions",
+                                        "name": "flux_TC_3_4.awg.playlist_repeats",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "sigouts_0_offset": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output 0 offset",
+                                        "name": "flux_TC_3_4.awg.sigouts_0_offset",
+                                        "unit": "V"
+                                    },
+                                    "value": 0
+                                },
+                                "sigouts_1_offset": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output 1 offset",
+                                        "name": "flux_TC_3_4.awg.sigouts_1_offset",
+                                        "unit": "V"
+                                    },
+                                    "value": 0
+                                },
+                                "sines_0_amplitudes_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 0 amplitude to wave output 0",
+                                        "name": "flux_TC_3_4.awg.sines_0_amplitudes_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "sines_1_amplitudes_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 1 amplitude to wave output 1",
+                                        "name": "flux_TC_3_4.awg.sines_1_amplitudes_1",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "status": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Output enabled",
+                                        "name": "flux_TC_3_4.awg.status",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                },
+                                "trigger_delay": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Delay between trigger output and pulse",
+                                        "name": "flux_TC_3_4.awg.trigger_delay",
+                                        "unit": "s"
+                                    },
+                                    "value": 0
+                                },
+                                "trigger_source": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Source of digital trigger",
+                                        "name": "flux_TC_3_4.awg.trigger_source",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                }
+                            },
+                            "subtrees": {}
+                        },
+                        "pulse": {
+                            "name": "flux_TC_3_4.pulse",
+                            "settings": {},
+                            "subtrees": {
+                                "channel_0": {
+                                    "name": "flux_TC_3_4.pulse.channel_0",
+                                    "settings": {
+                                        "amplitude": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": [
+                                                    1,
+                                                    2
+                                                ],
+                                                "label": "Pulse Amplitude",
+                                                "name": "flux_TC_3_4.pulse.channel_0.amplitude",
+                                                "unit": ""
+                                            },
+                                            "value": 1
+                                        },
+                                        "csv_dir": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse CSV Directory",
+                                                "name": "flux_TC_3_4.pulse.channel_0.csv_dir",
+                                                "unit": ""
+                                            },
+                                            "value": null
+                                        },
+                                        "duration": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Duration",
+                                                "name": "flux_TC_3_4.pulse.channel_0.duration",
+                                                "unit": "s"
+                                            },
+                                            "value": 1.1e-07
+                                        },
+                                        "duration_type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Duration Type",
+                                                "name": "flux_TC_3_4.pulse.channel_0.duration_type",
+                                                "unit": ""
+                                            },
+                                            "value": "TIME"
+                                        },
+                                        "filter_width": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Filter width",
+                                                "name": "flux_TC_3_4.pulse.channel_0.filter_width",
+                                                "unit": "s"
+                                            },
+                                            "value": 1e-08
+                                        },
+                                        "phase": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Phase",
+                                                "name": "flux_TC_3_4.pulse.channel_0.phase",
+                                                "unit": "rad"
+                                            },
+                                            "value": 0.0
+                                        },
+                                        "program_mode": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Program Mode",
+                                                "name": "flux_TC_3_4.pulse.channel_0.program_mode",
+                                                "unit": ""
+                                            },
+                                            "value": "PREDEFINED"
+                                        },
+                                        "rectangle_width": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Width",
+                                                "name": "flux_TC_3_4.pulse.channel_0.rectangle_width",
+                                                "unit": "s"
+                                            },
+                                            "value": 1e-07
+                                        },
+                                        "sampling_rate": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Sample Rate",
+                                                "name": "flux_TC_3_4.pulse.channel_0.sample_rate",
+                                                "unit": "Hz"
+                                            },
+                                            "value": 2400000000.0
+                                        },
+                                        "type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Type",
+                                                "name": "flux_TC_3_4.pulse.channel_0.type",
+                                                "unit": ""
+                                            },
+                                            "value": "ErfSquarePulse"
+                                        }
+                                    },
+                                    "subtrees": {}
+                                }
+                            }
+                        },
+                        "rz_angles": {
+                            "name": "rz_angles",
+                            "settings": {},
+                            "subtrees": {}
+                        }
+                    }
+                }
+            }
+        },
+        "TC_3_5": {
+            "name": "TC_3_5",
+            "settings": {},
+            "subtrees": {
+                "flux": {
+                    "name": "flux_TC_3_5",
+                    "settings": {
+                        "voltage": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Gate dac1",
+                                "name": "flux_TC_3_5.voltage",
+                                "unit": "V"
+                            },
+                            "value": 0.0
+                        }
+                    },
+                    "subtrees": {
+                        "awg": {
+                            "name": "flux_TC_3_5.awg",
+                            "settings": {
+                                "continuous_wave_amplitude": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Continuous sine output amplitude",
+                                        "name": "flux_TC_3_5.awg.continuous_wave_amplitude",
+                                        "unit": ""
+                                    },
+                                    "value": 0
+                                },
+                                "continuous_wave_enabled": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Continuous wave mode",
+                                        "name": "flux_TC_3_5.awg.continuous_wave_enabled",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "dac_downsampling_factor": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "DAC downsampling factor",
+                                        "name": "flux_TC_3_5.awg.dac_downsampling_factor",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "dac_rate": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "DAC rate",
+                                        "name": "flux_TC_3_5.awg.dac_rate",
+                                        "unit": "Hz"
+                                    },
+                                    "value": null
+                                },
+                                "end_delay": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Delay after pulse",
+                                        "name": "flux_TC_3_5.awg.end_delay",
+                                        "unit": "s"
+                                    },
+                                    "value": 0
+                                },
+                                "full_routing_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Full routing mode",
+                                        "name": "flux_TC_3_5.awg.full_routing_mode",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "is_master": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Is trigger master",
+                                        "name": "flux_TC_3_5.awg.is_master",
+                                        "unit": ""
+                                    },
+                                    "value": false
+                                },
+                                "max_output": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output ranges",
+                                        "name": "flux_TC_3_5.awg.max_output",
+                                        "unit": "V"
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_0_gains_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 0 gain 0",
+                                        "name": "flux_TC_3_5.awg.outputs_0_gains_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_0_gains_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 0 gain 1",
+                                        "name": "flux_TC_3_5.awg.outputs_0_gains_1",
+                                        "unit": ""
+                                    },
+                                    "value": -1.0
+                                },
+                                "outputs_0_modulation_carrier_0_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 0 oscillator",
+                                        "name": "flux_TC_3_5.awg.outputs_0_modulation_carrier_0_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_0_modulation_carrier_0_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 0 phase",
+                                        "name": "flux_TC_3_5.awg.outputs_0_modulation_carrier_0_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": 0
+                                },
+                                "outputs_0_modulation_carrier_1_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 1 oscillator",
+                                        "name": "flux_TC_3_5.awg.outputs_0_modulation_carrier_1_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_0_modulation_carrier_1_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 0 modulator 1 phase",
+                                        "name": "flux_TC_3_5.awg.outputs_0_modulation_carrier_1_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": -90
+                                },
+                                "outputs_0_modulation_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG output 0 modulation mode",
+                                        "name": "flux_TC_3_5.awg.outputs_0_modulation_mode",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "outputs_1_gains_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 1 gain 0",
+                                        "name": "flux_TC_3_5.awg.outputs_1_gains_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_1_gains_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG unit output 1 gain 1",
+                                        "name": "flux_TC_3_5.awg.outputs_1_gains_1",
+                                        "unit": ""
+                                    },
+                                    "value": 1.0
+                                },
+                                "outputs_1_modulation_carrier_0_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 0 oscillator",
+                                        "name": "flux_TC_3_5.awg.outputs_1_modulation_carrier_0_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_1_modulation_carrier_0_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 0 phase",
+                                        "name": "flux_TC_3_5.awg.outputs_1_modulation_carrier_0_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": 0
+                                },
+                                "outputs_1_modulation_carrier_1_oscselect": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 1 oscillator",
+                                        "name": "flux_TC_3_5.awg.outputs_1_modulation_carrier_1_oscselect",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "outputs_1_modulation_carrier_1_phaseshift": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Output 1 modulator 1 phase",
+                                        "name": "flux_TC_3_5.awg.outputs_1_modulation_carrier_1_phaseshift",
+                                        "unit": "deg"
+                                    },
+                                    "value": -90
+                                },
+                                "outputs_1_modulation_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "AWG output 1 modulation mode",
+                                        "name": "flux_TC_3_5.awg.outputs_1_modulation_mode",
+                                        "unit": ""
+                                    },
+                                    "value": 2
+                                },
+                                "phase_sensitive_mode": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Phase sensitive mode",
+                                        "name": "flux_TC_3_5.awg.phase_sensitive_mode",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                },
+                                "phase_shift_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 0 phase",
+                                        "name": "flux_TC_3_5.awg.phase_shift_0",
+                                        "unit": "rad"
+                                    },
+                                    "value": 0
+                                },
+                                "phase_shift_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 1 phase",
+                                        "name": "flux_TC_3_5.awg.phase_shift_1",
+                                        "unit": "rad"
+                                    },
+                                    "value": -1.5707963267948966
+                                },
+                                "playlist_repeats": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Number of repetitions",
+                                        "name": "flux_TC_3_5.awg.playlist_repeats",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                },
+                                "sigouts_0_offset": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output 0 offset",
+                                        "name": "flux_TC_3_5.awg.sigouts_0_offset",
+                                        "unit": "V"
+                                    },
+                                    "value": 0
+                                },
+                                "sigouts_1_offset": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Signal output 1 offset",
+                                        "name": "flux_TC_3_5.awg.sigouts_1_offset",
+                                        "unit": "V"
+                                    },
+                                    "value": 0
+                                },
+                                "sines_0_amplitudes_0": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 0 amplitude to wave output 0",
+                                        "name": "flux_TC_3_5.awg.sines_0_amplitudes_0",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "sines_1_amplitudes_1": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Sine generator 1 amplitude to wave output 1",
+                                        "name": "flux_TC_3_5.awg.sines_1_amplitudes_1",
+                                        "unit": ""
+                                    },
+                                    "value": 1
+                                },
+                                "status": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 4,
+                                        "label": "Output enabled",
+                                        "name": "flux_TC_3_5.awg.status",
+                                        "unit": ""
+                                    },
+                                    "value": true
+                                },
+                                "trigger_delay": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Delay between trigger output and pulse",
+                                        "name": "flux_TC_3_5.awg.trigger_delay",
+                                        "unit": "s"
+                                    },
+                                    "value": 0
+                                },
+                                "trigger_source": {
+                                    "parameter": {
+                                        "collection_type": 0,
+                                        "data_type": 1,
+                                        "label": "Source of digital trigger",
+                                        "name": "flux_TC_3_5.awg.trigger_source",
+                                        "unit": ""
+                                    },
+                                    "value": null
+                                }
+                            },
+                            "subtrees": {}
+                        },
+                        "pulse": {
+                            "name": "flux_TC_3_5.pulse",
+                            "settings": {},
+                            "subtrees": {
+                                "channel_0": {
+                                    "name": "flux_TC_3_5.pulse.channel_0",
+                                    "settings": {
+                                        "amplitude": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": [
+                                                    1,
+                                                    2
+                                                ],
+                                                "label": "Pulse Amplitude",
+                                                "name": "flux_TC_3_5.pulse.channel_0.amplitude",
+                                                "unit": ""
+                                            },
+                                            "value": 1
+                                        },
+                                        "csv_dir": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse CSV Directory",
+                                                "name": "flux_TC_3_5.pulse.channel_0.csv_dir",
+                                                "unit": ""
+                                            },
+                                            "value": null
+                                        },
+                                        "duration": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Duration",
+                                                "name": "flux_TC_3_5.pulse.channel_0.duration",
+                                                "unit": "s"
+                                            },
+                                            "value": 1.1e-07
+                                        },
+                                        "duration_type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Duration Type",
+                                                "name": "flux_TC_3_5.pulse.channel_0.duration_type",
+                                                "unit": ""
+                                            },
+                                            "value": "TIME"
+                                        },
+                                        "filter_width": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Filter width",
+                                                "name": "flux_TC_3_5.pulse.channel_0.filter_width",
+                                                "unit": "s"
+                                            },
+                                            "value": 1e-08
+                                        },
+                                        "phase": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Phase",
+                                                "name": "flux_TC_3_5.pulse.channel_0.phase",
+                                                "unit": "rad"
+                                            },
+                                            "value": 0.0
+                                        },
+                                        "program_mode": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Program Mode",
+                                                "name": "flux_TC_3_5.pulse.channel_0.program_mode",
+                                                "unit": ""
+                                            },
+                                            "value": "PREDEFINED"
+                                        },
+                                        "rectangle_width": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Width",
+                                                "name": "flux_TC_3_5.pulse.channel_0.rectangle_width",
+                                                "unit": "s"
+                                            },
+                                            "value": 1e-07
+                                        },
+                                        "sampling_rate": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 1,
+                                                "label": "Pulse Sample Rate",
+                                                "name": "flux_TC_3_5.pulse.channel_0.sample_rate",
+                                                "unit": "Hz"
+                                            },
+                                            "value": 2400000000.0
+                                        },
+                                        "type": {
+                                            "parameter": {
+                                                "collection_type": 0,
+                                                "data_type": 3,
+                                                "label": "Pulse Type",
+                                                "name": "flux_TC_3_5.pulse.channel_0.type",
+                                                "unit": ""
+                                            },
+                                            "value": "ErfSquarePulse"
+                                        }
+                                    },
+                                    "subtrees": {}
+                                }
+                            }
+                        },
+                        "rz_angles": {
+                            "name": "rz_angles",
+                            "settings": {},
+                            "subtrees": {}
+                        }
+                    }
+                }
+            }
+        },
+        "probe_line_1": {
+            "name": "probe_line_1",
+            "settings": {},
+            "subtrees": {
+                "local_oscillator": {
+                    "name": "ro_lo_multi_1",
+                    "settings": {
+                        "frequency": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "LO frequency",
+                                "name": "ro_lo_multi_1.frequency",
+                                "unit": "Hz"
+                            },
+                            "value": null
+                        },
+                        "phase": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Phase",
+                                "name": "ro_lo_multi_1.phase",
+                                "unit": "deg"
+                            },
+                            "value": null
+                        },
+                        "power": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Power",
+                                "name": "ro_lo_multi_1.power",
+                                "unit": "dBm"
+                            },
+                            "value": 10
+                        },
+                        "status": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 4,
+                                "label": "RF output enabled",
+                                "name": "ro_lo_multi_1.status",
+                                "unit": ""
+                            },
+                            "value": true
+                        }
+                    },
+                    "subtrees": {}
+                },
+                "readout": {
+                    "name": "readout_multi_1",
+                    "settings": {
+                        "amplitude": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Readout amplitude",
+                                "name": "readout_multi_1.amplitude",
+                                "unit": ""
+                            },
+                            "value": 1.0
+                        },
+                        "average_count": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Number of averages",
+                                "name": "readout_multi_1.average_count",
+                                "unit": ""
+                            },
+                            "value": 1
+                        },
+                        "dac_downsampling_factor": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "DAC downsampling factor",
+                                "name": "readout_multi_1.dac_downsampling_factor",
+                                "unit": ""
+                            },
+                            "value": 1
+                        },
+                        "delay_after_pulse_0": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Delay between pulses 0 and 1",
+                                "name": "readout_multi_1.delay_after_pulse_0",
+                                "unit": ""
+                            },
+                            "value": 0
+                        },
+                        "delay_before_integration": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Acquisition delay",
+                                "name": "readout_multi_1.delay_before_integration",
+                                "unit": "s"
+                            },
+                            "value": 2e-07
+                        },
+                        "end_delay": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "End delay",
+                                "name": "readout_multi_1.end_delay",
+                                "unit": "s"
+                            },
+                            "value": 1e-07
+                        },
+                        "input_range": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Signal input range",
+                                "name": "readout_multi_1.input_range",
+                                "unit": ""
+                            },
+                            "value": 1.5
+                        },
+                        "integration_length": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Integration length",
+                                "name": "readout_multi_1.integration_length",
+                                "unit": "s"
+                            },
+                            "value": 2e-06
+                        },
+                        "is_master": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 4,
+                                "label": "Is trigger master",
+                                "name": "readout_multi_1.is_master",
+                                "unit": ""
+                            },
+                            "value": false
+                        },
+                        "max_output": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Signal outuput max range",
+                                "name": "readout_multi_1.max_output",
+                                "unit": ""
+                            },
+                            "value": 0.75
+                        },
+                        "monitor_enabled": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 4,
+                                "label": "Enable input monitor",
+                                "name": "readout_multi_1.monitor_enabled",
+                                "unit": ""
+                            },
+                            "value": false
+                        },
+                        "pulse_begin_delay": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Delay before final pulse",
+                                "name": "readout_multi_1.pulse_begin_delay",
+                                "unit": "s"
+                            },
+                            "value": 2e-05
+                        },
+                        "pulse_ratio": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Ratio of I and Q amplitudes",
+                                "name": "readout_multi_1.pulse_ratio",
+                                "unit": ""
+                            },
+                            "value": 1
+                        },
+                        "result_enabled": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 4,
+                                "label": "Enable result logging",
+                                "name": "readout_multi_1.result_enabled",
+                                "unit": ""
+                            },
+                            "value": true
+                        },
+                        "result_length": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Segment count",
+                                "name": "readout_multi_1.result_length",
+                                "unit": ""
+                            },
+                            "value": 1
+                        },
+                        "result_source": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Result logging source",
+                                "name": "readout_multi_1.result_source",
+                                "unit": ""
+                            },
+                            "value": 1
+                        },
+                        "time_trace": {
+                            "parameter": {
+                                "collection_type": 2,
+                                "data_type": 2,
+                                "label": "Time trace",
+                                "name": "readout_multi_1.time_trace",
+                                "unit": "V"
+                            },
+                            "value": null
+                        },
+                        "trigger_delay": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Delay after trigger",
+                                "name": "readout_multi_1.trigger_delay",
+                                "unit": ""
+                            },
+                            "value": 0
+                        },
+                        "trigger_source": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Trigger source",
+                                "name": "readout_multi_1.trigger_source",
+                                "unit": ""
+                            },
+                            "value": 1
+                        }
+                    },
+                    "subtrees": {}
+                }
+            }
+        },
+        "probe_line_2": {
+            "name": "probe_line_2",
+            "settings": {},
+            "subtrees": {
+                "local_oscillator": {
+                    "name": "ro_lo_multi_2",
+                    "settings": {
+                        "frequency": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "LO frequency",
+                                "name": "ro_lo_multi_2.frequency",
+                                "unit": "Hz"
+                            },
+                            "value": null
+                        },
+                        "phase": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Phase",
+                                "name": "ro_lo_multi_2.phase",
+                                "unit": "deg"
+                            },
+                            "value": null
+                        },
+                        "power": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Power",
+                                "name": "ro_lo_multi_2.power",
+                                "unit": "dBm"
+                            },
+                            "value": 10
+                        },
+                        "status": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 4,
+                                "label": "RF output enabled",
+                                "name": "ro_lo_multi_2.status",
+                                "unit": ""
+                            },
+                            "value": true
+                        }
+                    },
+                    "subtrees": {}
+                },
+                "readout": {
+                    "name": "readout_multi_2",
+                    "settings": {
+                        "amplitude": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Readout amplitude",
+                                "name": "readout_multi_2.amplitude",
+                                "unit": ""
+                            },
+                            "value": 1.0
+                        },
+                        "average_count": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Number of averages",
+                                "name": "readout_multi_2.average_count",
+                                "unit": ""
+                            },
+                            "value": 1
+                        },
+                        "dac_downsampling_factor": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "DAC downsampling factor",
+                                "name": "readout_multi_2.dac_downsampling_factor",
+                                "unit": ""
+                            },
+                            "value": 1
+                        },
+                        "delay_after_pulse_0": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Delay between pulses 0 and 1",
+                                "name": "readout_multi_2.delay_after_pulse_0",
+                                "unit": ""
+                            },
+                            "value": 0
+                        },
+                        "delay_before_integration": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Acquisition delay",
+                                "name": "readout_multi_2.delay_before_integration",
+                                "unit": "s"
+                            },
+                            "value": 2e-07
+                        },
+                        "end_delay": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "End delay",
+                                "name": "readout_multi_2.end_delay",
+                                "unit": "s"
+                            },
+                            "value": 1e-07
+                        },
+                        "input_range": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Signal input range",
+                                "name": "readout_multi_2.input_range",
+                                "unit": ""
+                            },
+                            "value": 1.5
+                        },
+                        "integration_length": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Integration length",
+                                "name": "readout_multi_2.integration_length",
+                                "unit": "s"
+                            },
+                            "value": 2e-06
+                        },
+                        "is_master": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 4,
+                                "label": "Is trigger master",
+                                "name": "readout_multi_2.is_master",
+                                "unit": ""
+                            },
+                            "value": false
+                        },
+                        "max_output": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Signal outuput max range",
+                                "name": "readout_multi_2.max_output",
+                                "unit": ""
+                            },
+                            "value": 0.75
+                        },
+                        "monitor_enabled": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 4,
+                                "label": "Enable input monitor",
+                                "name": "readout_multi_2.monitor_enabled",
+                                "unit": ""
+                            },
+                            "value": false
+                        },
+                        "pulse_begin_delay": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Delay before final pulse",
+                                "name": "readout_multi_2.pulse_begin_delay",
+                                "unit": "s"
+                            },
+                            "value": 2e-05
+                        },
+                        "pulse_ratio": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Ratio of I and Q amplitudes",
+                                "name": "readout_multi_2.pulse_ratio",
+                                "unit": ""
+                            },
+                            "value": 1
+                        },
+                        "result_enabled": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 4,
+                                "label": "Enable result logging",
+                                "name": "readout_multi_2.result_enabled",
+                                "unit": ""
+                            },
+                            "value": true
+                        },
+                        "result_length": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Segment count",
+                                "name": "readout_multi_2.result_length",
+                                "unit": ""
+                            },
+                            "value": 1
+                        },
+                        "result_source": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Result logging source",
+                                "name": "readout_multi_2.result_source",
+                                "unit": ""
+                            },
+                            "value": 1
+                        },
+                        "time_trace": {
+                            "parameter": {
+                                "collection_type": 2,
+                                "data_type": 2,
+                                "label": "Time trace",
+                                "name": "readout_multi_2.time_trace",
+                                "unit": "V"
+                            },
+                            "value": null
+                        },
+                        "trigger_delay": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Delay after trigger",
+                                "name": "readout_multi_2.trigger_delay",
+                                "unit": ""
+                            },
+                            "value": 0
+                        },
+                        "trigger_source": {
+                            "parameter": {
+                                "collection_type": 0,
+                                "data_type": 1,
+                                "label": "Trigger source",
+                                "name": "readout_multi_2.trigger_source",
+                                "unit": ""
+                            },
+                            "value": 1
+                        }
+                    },
+                    "subtrees": {}
+                }
+            }
+        }
+    }
+}

--- a/modules/pytket-iqm/pytket/extensions/iqm/backends/iqm.py
+++ b/modules/pytket-iqm/pytket/extensions/iqm/backends/iqm.py
@@ -341,4 +341,4 @@ def _iqm_rebase() -> BasePass:
     return RebaseCustom({OpType.CZ}, c_cx, {OpType.PhasedX}, c_tk1)
 
 
-_xcirc = Circuit(1).add_gate(OpType.PhasedX, [1, 0], [0])
+_xcirc = Circuit(1).add_gate(OpType.PhasedX, [1, 0], [0]).add_phase(0.5)

--- a/modules/pytket-iqm/pytket/extensions/iqm/backends/iqm.py
+++ b/modules/pytket-iqm/pytket/extensions/iqm/backends/iqm.py
@@ -1,0 +1,343 @@
+# Copyright 2020-2022 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from os import PathLike
+from pathlib import Path
+from typing import cast, Dict, List, Optional, Sequence, Tuple, Union
+from uuid import UUID
+from iqm_client.iqm_client import Circuit as IQMCircuit  # type: ignore
+from iqm_client.iqm_client import (  # type: ignore
+    Instruction,
+    IQMClient,
+    RunStatus,
+    SingleQubitMapping,
+)
+import numpy as np
+from pytket.backends import Backend, CircuitStatus, ResultHandle, StatusEnum
+from pytket.backends.backend import KwargTypes
+from pytket.backends.backend_exceptions import CircuitNotRunError
+from pytket.backends.backendinfo import BackendInfo
+from pytket.backends.backendresult import BackendResult
+from pytket.backends.resulthandle import _ResultIdTuple
+from pytket.circuit import Circuit, Node, OpType  # type: ignore
+from pytket.extensions.iqm._metadata import __extension_version__
+from pytket.passes import (  # type: ignore
+    BasePass,
+    SequencePass,
+    SynthesiseTket,
+    FullPeepholeOptimise,
+    FlattenRegisters,
+    RebaseCustom,
+    DecomposeBoxes,
+    RemoveRedundancies,
+    DefaultMappingPass,
+    DelayMeasures,
+    SimplifyInitial,
+)
+from pytket.predicates import (  # type: ignore
+    ConnectivityPredicate,
+    GateSetPredicate,
+    NoClassicalControlPredicate,
+    NoFastFeedforwardPredicate,
+    NoMidMeasurePredicate,
+    NoSymbolsPredicate,
+    Predicate,
+)
+from pytket.routing import Architecture  # type: ignore
+from pytket.utils import prepare_circuit
+from pytket.utils.outcomearray import OutcomeArray
+from .config import IQMConfig
+
+_GATE_SET = {OpType.PhasedX, OpType.CZ, OpType.Measure}
+
+_DEFAULT_SETTINGS = Path(__file__).resolve().parent / "demo_settings.json"
+
+_DEFAULT_COUPLING = [
+    ("QB1", "QB3"),
+    ("QB2", "QB3"),
+    ("QB4", "QB3"),
+    ("QB5", "QB3"),
+]
+
+
+class IqmAuthenticationError(Exception):
+    """Raised when there is no IQM access credentials available."""
+
+    def __init__(self) -> None:
+        super().__init__("No IQM access credentials provided or found in config file.")
+
+
+class IQMBackend(Backend):
+    """
+    Interface to an IQM device or simulator.
+    """
+
+    _supports_shots = True
+    _supports_counts = True
+    _supports_contextual_optimisation = True
+    _persistent_handles = True
+
+    def __init__(
+        self,
+        url: str = "https://cortex-demo.qc.iqm.fi/",
+        device: PathLike = _DEFAULT_SETTINGS,
+        arch: Optional[List[Tuple[str, str]]] = None,
+        username: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ):
+        """
+        Construct a new IQM backend.
+
+        Requires a valid username and API key. These can either be provided as
+        parameters or set in config using
+        :py:meth:`pytket.extensions.iqm.set_aqt_config`.
+
+        :param url: base URL for requests
+        :param device: path of JSON file containing device settings
+        :param arch: list of couplings between the qubits defined in the device settings
+            (default: [("QB1", "QB3"), ("QB2", "QB3"), ("QB4", "QB3"), ("QB5", "QB3")])
+        :param username: IQM username
+        :param api_key: IQM API key
+        """
+        super().__init__()
+        self._url = url
+        config = IQMConfig.from_default_config_file()
+
+        if username is None:
+            username = config.username
+        if username is None:
+            raise IqmAuthenticationError()
+        if api_key is None:
+            api_key = config.api_key
+        if api_key is None:
+            raise IqmAuthenticationError()
+
+        with open(device) as f:
+            settings = json.load(f)
+        self._client = IQMClient(
+            self._url, settings=settings, username=username, api_key=api_key
+        )
+        self._qubits = [
+            _as_node(qb) for qb in settings["subtrees"].keys() if qb.startswith("QB")
+        ]
+        self._n_qubits = len(self._qubits)
+        if arch is None:
+            arch = _DEFAULT_COUPLING
+        coupling = [(_as_node(a), _as_node(b)) for (a, b) in arch]
+        if any(qb not in self._qubits for couple in coupling for qb in couple):
+            raise ValueError("Architecture contains qubits not in device")
+        self._arch = Architecture(coupling)
+        self._backendinfo = BackendInfo(
+            type(self).__name__,
+            settings["name"],
+            __extension_version__,
+            self._arch,
+            _GATE_SET,
+        )
+
+    @property
+    def backend_info(self) -> BackendInfo:
+        return self._backendinfo
+
+    @property
+    def required_predicates(self) -> List[Predicate]:
+        return [
+            NoClassicalControlPredicate(),
+            NoFastFeedforwardPredicate(),
+            NoMidMeasurePredicate(),
+            NoSymbolsPredicate(),
+            GateSetPredicate(_GATE_SET),
+            ConnectivityPredicate(self._arch),
+        ]
+
+    def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:
+        assert optimisation_level in range(3)
+        passes = [DecomposeBoxes(), FlattenRegisters()]
+        if optimisation_level == 1:
+            passes.append(SynthesiseTket())
+        elif optimisation_level == 2:
+            passes.append(FullPeepholeOptimise())
+        passes.append(_iqm_rebase())  # to satisfy MaxTwoQubitGatesPredicate
+        passes.append(DefaultMappingPass(self._arch))
+        passes.append(DelayMeasures())
+        passes.append(_iqm_rebase())
+        passes.append(RemoveRedundancies())
+        if optimisation_level >= 1:
+            passes.append(
+                SimplifyInitial(
+                    allow_classical=False, create_all_qubits=True, xcirc=_xcirc
+                )
+            )
+        return SequencePass(passes)
+
+    @property
+    def _result_id_type(self) -> _ResultIdTuple:
+        return (bytes, str)
+
+    def process_circuits(
+        self,
+        circuits: Sequence[Circuit],
+        n_shots: Union[None, int, Sequence[Optional[int]]] = None,
+        valid_check: bool = True,
+        **kwargs: KwargTypes,
+    ) -> List[ResultHandle]:
+        """
+        See :py:meth:`pytket.backends.Backend.process_circuits`.
+        Supported kwargs: `postprocess`.
+        """
+        circuits = list(circuits)
+        n_shots_list = Backend._get_n_shots_as_list(
+            n_shots,
+            len(circuits),
+            optional=False,
+        )
+
+        if valid_check:
+            self._check_all_circuits(circuits)
+
+        postprocess = kwargs.get("postprocess", False)
+
+        handles = []
+        for i, (c, n_shots) in enumerate(zip(circuits, n_shots_list)):
+            if postprocess:
+                c0, ppcirc = prepare_circuit(c, allow_classical=False, xcirc=_xcirc)
+                ppcirc_rep = ppcirc.to_dict()
+            else:
+                c0, ppcirc_rep = c, None
+            instrs = _translate_iqm(c0)
+            qm = [
+                SingleQubitMapping(logical_name=str(qb), physical_name=_as_name(qb))
+                for qb in c.qubits
+            ]
+            iqmc = IQMCircuit(
+                name=c.name if c.name else f"circuit_{i}", instructions=instrs
+            )
+            run_id = self._client.submit_circuit(iqmc, qm, shots=n_shots)
+            handles.append(ResultHandle(run_id.bytes, json.dumps(ppcirc_rep)))
+        for handle in handles:
+            self._cache[handle] = dict()
+        return handles
+
+    def _update_cache_result(
+        self, handle: ResultHandle, result_dict: Dict[str, BackendResult]
+    ) -> None:
+        if handle in self._cache:
+            self._cache[handle].update(result_dict)
+        else:
+            self._cache[handle] = result_dict
+
+    def circuit_status(self, handle: ResultHandle) -> CircuitStatus:
+        self._check_handle_type(handle)
+        run_id = UUID(bytes=cast(bytes, handle[0]))
+        run_result = self._client.get_run(run_id)
+        status = run_result.status
+        if status is RunStatus.PENDING:
+            return CircuitStatus(StatusEnum.SUBMITTED)
+        elif status is RunStatus.READY:
+            measurements = run_result.measurements
+            shots = OutcomeArray.from_readouts(
+                np.array(
+                    [[r[0] for r in rlist] for cbstr, rlist in measurements.items()],
+                    dtype=int,
+                )
+                .transpose()
+                .tolist()
+            )
+            ppcirc_rep = json.loads(cast(str, handle[1]))
+            ppcirc = Circuit.from_dict(ppcirc_rep) if ppcirc_rep is not None else None
+            self._update_cache_result(
+                handle, {"result": BackendResult(shots=shots, ppcirc=ppcirc)}
+            )
+            return CircuitStatus(StatusEnum.COMPLETED)
+        else:
+            assert status is RunStatus.FAILED
+            return CircuitStatus(StatusEnum.ERROR, run_result.message)
+
+    def get_result(self, handle: ResultHandle, **kwargs: KwargTypes) -> BackendResult:
+        """
+        See :py:meth:`pytket.backends.Backend.get_result`.
+        Supported kwargs: `timeout` (default 900).
+        """
+        try:
+            return super().get_result(handle)
+        except CircuitNotRunError:
+            timeout = kwargs.get("timeout", 900)
+            # Wait for job to finish; result will then be in the cache.
+            run_id = UUID(bytes=cast(bytes, handle[0]))
+            self._client.wait_for_results(run_id, timeout_secs=timeout)
+            circuit_status = self.circuit_status(handle)
+            if circuit_status.status is StatusEnum.COMPLETED:
+                return cast(BackendResult, self._cache[handle]["result"])
+            else:
+                assert circuit_status.status is StatusEnum.ERROR
+                raise RuntimeError(circuit_status.message)
+
+
+def _as_node(qname: str) -> Node:
+    assert qname.startswith("QB")
+    x = int(qname[2:])
+    assert x >= 1
+    return Node(x - 1)
+
+
+def _as_name(qnode: Node) -> str:
+    assert qnode.reg_name == "node"
+    return f"QB{qnode.index[0] + 1}"
+
+
+def _translate_iqm(circ: Circuit) -> List[Instruction]:
+    """Convert a circuit in the IQM gate set to IQM list representation."""
+    instrs = []
+    for cmd in circ.get_commands():
+        op = cmd.op
+        qbs = cmd.qubits
+        cbs = cmd.bits
+        optype = op.type
+        params = op.params
+        if optype == OpType.PhasedX:
+            instr = Instruction(
+                name="phased_rx",
+                qubits=[str(qbs[0])],
+                args={"angle_t": 0.5 * params[0], "phase_t": 0.5 * params[1]},
+            )
+        elif optype == OpType.CZ:
+            instr = Instruction(name="cz", qubits=[str(qbs[0]), str(qbs[1])], args={})
+        else:
+            assert optype == OpType.Measure
+            instr = Instruction(
+                name="measurement", qubits=[str(qbs[0])], args={"key": str(cbs[0])}
+            )
+        instrs.append(instr)
+    return instrs
+
+
+def _iqm_rebase() -> BasePass:
+    # CX replacement
+    c_cx = Circuit(2)
+    c_cx.add_gate(OpType.PhasedX, [-0.5, 0.5], [1])
+    c_cx.CZ(0, 1)
+    c_cx.add_gate(OpType.PhasedX, [0.5, 0.5], [1])
+
+    # TK1 replacement
+    c_tk1 = (
+        lambda a, b, c: Circuit(1)
+        .add_gate(OpType.PhasedX, [-1, (a - c) / 2], [0])
+        .add_gate(OpType.PhasedX, [1 + b, a], [0])
+    )
+
+    return RebaseCustom({OpType.CZ}, c_cx, {OpType.PhasedX}, c_tk1)
+
+
+_xcirc = Circuit(1).add_gate(OpType.PhasedX, [1, 0], [0])

--- a/modules/pytket-iqm/pytket/extensions/iqm/backends/iqm.py
+++ b/modules/pytket-iqm/pytket/extensions/iqm/backends/iqm.py
@@ -108,7 +108,8 @@ class IQMBackend(Backend):
         :param url: base URL for requests
         :param device: path of JSON file containing device settings
         :param arch: list of couplings between the qubits defined in the device settings
-            (default: [("QB1", "QB3"), ("QB2", "QB3"), ("QB4", "QB3"), ("QB5", "QB3")])
+            (default: [("QB1", "QB3"), ("QB2", "QB3"), ("QB4", "QB3"), ("QB5", "QB3")],
+            i.e. a 5-qubit star topology centred on "QB3")
         :param username: IQM username
         :param api_key: IQM API key
         """

--- a/modules/pytket-iqm/pytket/extensions/iqm/backends/iqm.py
+++ b/modules/pytket-iqm/pytket/extensions/iqm/backends/iqm.py
@@ -64,6 +64,7 @@ _GATE_SET = {OpType.PhasedX, OpType.CZ, OpType.Measure}
 
 _DEFAULT_SETTINGS = Path(__file__).resolve().parent / "demo_settings.json"
 
+# https://iqm-finland.github.io/cirq-on-iqm/api/cirq_iqm.devices.adonis.Adonis.html
 _DEFAULT_COUPLING = [
     ("QB1", "QB3"),
     ("QB2", "QB3"),

--- a/modules/pytket-iqm/pytket/extensions/iqm/backends/iqm.py
+++ b/modules/pytket-iqm/pytket/extensions/iqm/backends/iqm.py
@@ -167,11 +167,12 @@ class IQMBackend(Backend):
     def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:
         assert optimisation_level in range(3)
         passes = [DecomposeBoxes(), FlattenRegisters()]
-        if optimisation_level == 1:
+        if optimisation_level == 0:
+            passes.append(_iqm_rebase())  # to satisfy MaxTwoQubitGatesPredicate
+        elif optimisation_level == 1:
             passes.append(SynthesiseTket())
         elif optimisation_level == 2:
             passes.append(FullPeepholeOptimise())
-        passes.append(_iqm_rebase())  # to satisfy MaxTwoQubitGatesPredicate
         passes.append(DefaultMappingPass(self._arch))
         passes.append(DelayMeasures())
         passes.append(_iqm_rebase())

--- a/modules/pytket-iqm/setup.py
+++ b/modules/pytket-iqm/setup.py
@@ -1,0 +1,53 @@
+# Copyright 2020-2022 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import shutil
+import os
+from setuptools import setup, find_namespace_packages  # type: ignore
+
+metadata: dict = {}
+with open("_metadata.py") as fp:
+    exec(fp.read(), metadata)
+shutil.copy(
+    "_metadata.py",
+    os.path.join("pytket", "extensions", "iqm", "_metadata.py"),
+)
+
+setup(
+    name=metadata["__extension_name__"],
+    version=metadata["__extension_version__"],
+    author="Alec Edgington",
+    author_email="alec.edgington@cambridgequantum.com",
+    python_requires=">=3.9",
+    url="https://github.com/CQCL/pytket-extensions",
+    description="Extension for pytket, providing access to IQM backends",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+    license="Apache 2",
+    packages=find_namespace_packages(include=["pytket.*"]),
+    include_package_data=True,
+    install_requires=["pytket ~= 0.18.0", "iqm-client ~= 1.6"],
+    classifiers=[
+        "Environment :: Console",
+        "Programming Language :: Python :: 3.9",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: MacOS :: MacOS X",
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: Microsoft :: Windows",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering",
+    ],
+    zip_safe=False,
+)

--- a/modules/pytket-iqm/tests/backend_test.py
+++ b/modules/pytket-iqm/tests/backend_test.py
@@ -84,7 +84,7 @@ def test_handles() -> None:
 
 
 def test_default_pass() -> None:
-    b = IQMBackend()
+    b = IQMBackend(username="invalid", api_key="invalid")
     for ol in range(3):
         comp_pass = b.default_compilation_pass(ol)
         c = Circuit(3, 3)
@@ -99,7 +99,7 @@ def test_default_pass() -> None:
 
 
 def test_backendinfo() -> None:
-    b = IQMBackend()
+    b = IQMBackend(username="invalid", api_key="invalid")
     info = b.backend_info
     assert info.name == type(b).__name__
     assert len(info.gate_set) >= 3

--- a/modules/pytket-iqm/tests/backend_test.py
+++ b/modules/pytket-iqm/tests/backend_test.py
@@ -83,6 +83,18 @@ def test_handles() -> None:
         assert result.get_shots().shape == (n_shots, 2)
 
 
+def test_none_nshots() -> None:
+    b = IQMBackend()
+    c = Circuit(2, 2)
+    c.H(0)
+    c.CX(0, 1)
+    c.measure_all()
+    c = b.get_compiled_circuit(c)
+    with pytest.raises(ValueError) as errorinfo:
+        h = b.process_circuits([c])
+    assert "Parameter n_shots is required" in str(errorinfo.value)
+
+
 def test_default_pass() -> None:
     b = IQMBackend(username="invalid", api_key="invalid")
     for ol in range(3):

--- a/modules/pytket-iqm/tests/backend_test.py
+++ b/modules/pytket-iqm/tests/backend_test.py
@@ -98,6 +98,22 @@ def test_default_pass() -> None:
             assert pred.verify(c)
 
 
+@pytest.mark.skipif(skip_remote_tests, reason=REASON)
+def test_postprocess() -> None:
+    b = IQMBackend()
+    assert b.supports_contextual_optimisation
+    c = Circuit(2, 2)
+    c.Y(0)
+    c.Z(1)
+    c.measure_all()
+    c = b.get_compiled_circuit(c)
+    h = b.process_circuit(c, n_shots=10, postprocess=True)
+    r = b.get_result(h)
+    shots = r.get_shots()
+    assert len(shots) == 10
+    assert all(len(shot) == 2 for shot in shots)
+
+
 def test_backendinfo() -> None:
     b = IQMBackend(username="invalid", api_key="invalid")
     info = b.backend_info

--- a/modules/pytket-iqm/tests/backend_test.py
+++ b/modules/pytket-iqm/tests/backend_test.py
@@ -83,6 +83,7 @@ def test_handles() -> None:
         assert result.get_shots().shape == (n_shots, 2)
 
 
+@pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_none_nshots() -> None:
     b = IQMBackend()
     c = Circuit(2, 2)

--- a/modules/pytket-iqm/tests/backend_test.py
+++ b/modules/pytket-iqm/tests/backend_test.py
@@ -1,0 +1,105 @@
+# Copyright 2019-2022 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pytest
+from pytket.circuit import Circuit  # type: ignore
+from pytket.backends import StatusEnum
+from pytket.extensions.iqm import IQMBackend
+from requests import HTTPError
+
+skip_remote_tests: bool = os.getenv("PYTKET_RUN_REMOTE_TESTS") is None
+REASON = "PYTKET_RUN_REMOTE_TESTS not set (requires configuration of IQM credentials)"
+
+
+@pytest.mark.skipif(skip_remote_tests, reason=REASON)
+def test_iqm() -> None:
+    # Run a circuit on the demo device.
+    b = IQMBackend()
+    c = Circuit(4, 4)
+    c.H(0)
+    c.CX(0, 1)
+    c.Rz(0.3, 2)
+    c.CSWAP(0, 1, 2)
+    c.CRz(0.4, 2, 3)
+    c.CY(1, 3)
+    c.ZZPhase(0.1, 2, 0)
+    c.Tdg(3)
+    c.measure_all()
+    c = b.get_compiled_circuit(c)
+    n_shots = 10
+    res = b.run_circuit(c, n_shots=n_shots, timeout=30)
+    shots = res.get_shots()
+    counts = res.get_counts()
+    assert len(shots) == n_shots
+    assert sum(counts.values()) == n_shots
+
+
+def test_invalid_cred() -> None:
+    b = IQMBackend(username="invalid", api_key="invalid")
+    c = Circuit(2, 2).H(0).CX(0, 1)
+    c.measure_all()
+    c = b.get_compiled_circuit(c)
+    with pytest.raises(HTTPError):
+        b.process_circuit(c, 1)
+
+
+@pytest.mark.skipif(skip_remote_tests, reason=REASON)
+def test_handles() -> None:
+    b = IQMBackend()
+    c = Circuit(2, 2)
+    c.H(0)
+    c.CX(0, 1)
+    c.measure_all()
+    c = b.get_compiled_circuit(c)
+    n_shots = 5
+    res = b.run_circuit(c, n_shots=n_shots, timeout=30)
+    shots = res.get_shots()
+    assert len(shots) == n_shots
+    counts = res.get_counts()
+    assert sum(counts.values()) == n_shots
+    handles = b.process_circuits([c, c], n_shots=n_shots)
+    assert len(handles) == 2
+    for handle in handles:
+        assert b.circuit_status(handle).status in [
+            StatusEnum.SUBMITTED,
+            StatusEnum.COMPLETED,
+        ]
+    results = b.get_results(handles)
+    for handle in handles:
+        assert b.circuit_status(handle).status == StatusEnum.COMPLETED
+    for result in results:
+        assert result.get_shots().shape == (n_shots, 2)
+
+
+def test_default_pass() -> None:
+    b = IQMBackend()
+    for ol in range(3):
+        comp_pass = b.default_compilation_pass(ol)
+        c = Circuit(3, 3)
+        c.H(0)
+        c.CX(0, 1)
+        c.CSWAP(1, 0, 2)
+        c.ZZPhase(0.84, 2, 0)
+        c.measure_all()
+        comp_pass.apply(c)
+        for pred in b.required_predicates:
+            assert pred.verify(c)
+
+
+def test_backendinfo() -> None:
+    b = IQMBackend()
+    info = b.backend_info
+    assert info.name == type(b).__name__
+    assert len(info.gate_set) >= 3

--- a/modules/pytket-iqm/tests/backend_test.py
+++ b/modules/pytket-iqm/tests/backend_test.py
@@ -91,7 +91,7 @@ def test_none_nshots() -> None:
     c.measure_all()
     c = b.get_compiled_circuit(c)
     with pytest.raises(ValueError) as errorinfo:
-        h = b.process_circuits([c])
+        _ = b.process_circuits([c])
     assert "Parameter n_shots is required" in str(errorinfo.value)
 
 

--- a/modules/pytket-iqm/tests/convert_test.py
+++ b/modules/pytket-iqm/tests/convert_test.py
@@ -1,0 +1,70 @@
+# Copyright 2020-2022 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+import os
+import numpy as np
+from pytket.circuit import Circuit, OpType  # type: ignore
+from pytket.extensions.iqm.backends.iqm import _translate_iqm, IQMBackend, _iqm_rebase
+
+skip_remote_tests: bool = os.getenv("PYTKET_RUN_REMOTE_TESTS") is None
+REASON = "PYTKET_RUN_REMOTE_TESTS not set (requires configuration of IQM credentials)"
+
+
+def tk_to_iqm(circ: Circuit) -> List:
+    """Convert a circuit to IQM list representation"""
+    c = circ.copy()
+    IQMBackend().default_compilation_pass().apply(c)
+    return _translate_iqm(c)
+
+
+def test_rebase_CX() -> None:
+    circ = Circuit(2)
+    circ.CX(0, 1)
+    orig_circ = circ.copy()
+
+    _iqm_rebase().apply(circ)
+
+    u1 = orig_circ.get_unitary()
+    u2 = circ.get_unitary()
+
+    assert np.allclose(u1, u2)
+
+
+def test_rebase_singleq() -> None:
+    circ = Circuit(1)
+    # some arbitrary unitary
+    circ.add_gate(OpType.U3, [0.2, 0.3, 0.45], [0])
+    orig_circ = circ.copy()
+
+    _iqm_rebase().apply(circ)
+
+    u1 = orig_circ.get_unitary()
+    u2 = circ.get_unitary()
+
+    assert np.allclose(u1, u2)
+
+
+def test_rebase_large() -> None:
+    circ = Circuit(3)
+    # some arbitrary unitary
+    circ.Rx(0.2, 0).Rz(0.1, 1).Rz(8.2, 2).X(2).CX(0, 1).CX(1, 2).Rz(0.4, 1).Rx(0.7, 0)
+    orig_circ = circ.copy()
+
+    _iqm_rebase().apply(circ)
+
+    u1 = orig_circ.get_unitary()
+    u2 = circ.get_unitary()
+
+    assert np.allclose(u1, u2)

--- a/modules/pytket-iqm/tests/test-requirements.txt
+++ b/modules/pytket-iqm/tests/test-requirements.txt
@@ -1,0 +1,2 @@
+-r ../../base-test-requirements.txt
+types-requests


### PR DESCRIPTION
Tested only on the "demo" device (which is not a simulator but just produces pseudo-random bits). Other devices may be specified by passing parameters to the `IQMBackend` constructor. Credentials (`username` and `api_key`) may be stored in the pytket config file (with the key `iqm`), or passed directly to the constructor.