### PR TITLE
Update Backend objects to use rebase_pass abstract method

### DIFF
--- a/modules/pytket-aqt/pytket/extensions/aqt/backends/aqt.py
+++ b/modules/pytket-aqt/pytket/extensions/aqt/backends/aqt.py
@@ -143,6 +143,9 @@ class AQTBackend(Backend):
             }
         self._MACHINE_DEBUG = False
 
+    def rebase_pass(self) -> BasePass:
+        return _aqt_rebase()
+
     @property
     def backend_info(self) -> Optional[BackendInfo]:
         return self._backend_info
@@ -186,7 +189,7 @@ class AQTBackend(Backend):
                     FlattenRegisters(),
                     RenameQubitsPass(self._qm),
                     DecomposeBoxes(),
-                    _aqt_rebase(),
+                    self.rebase_pass(),
                 ]
             )
         elif optimisation_level == 1:
@@ -196,7 +199,7 @@ class AQTBackend(Backend):
                     SynthesiseTket(),
                     FlattenRegisters(),
                     RenameQubitsPass(self._qm),
-                    _aqt_rebase(),
+                    self.rebase_pass(),
                     SimplifyInitial(
                         allow_classical=False, create_all_qubits=True, xcirc=_xcirc
                     ),
@@ -210,7 +213,7 @@ class AQTBackend(Backend):
                     FullPeepholeOptimise(),
                     FlattenRegisters(),
                     RenameQubitsPass(self._qm),
-                    _aqt_rebase(),
+                    self.rebase_pass(),
                     SimplifyInitial(
                         allow_classical=False, create_all_qubits=True, xcirc=_xcirc
                     ),

--- a/modules/pytket-aqt/setup.py
+++ b/modules/pytket-aqt/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 0.19.0rc0", "requests ~= 2.22", "types-requests"],
+    install_requires=["pytket == 0.19.0rc1", "requests ~= 2.22", "types-requests"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
+++ b/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
@@ -363,6 +363,7 @@ class BraketBackend(Backend):
             lambda a, b, c: Circuit(1).Rz(c, 0).Rx(b, 0).Rz(a, 0),
         )
 
+
     @staticmethod
     def _get_gate_set(
         supported_ops: Set[str], device_type: _DeviceType
@@ -501,6 +502,9 @@ class BraketBackend(Backend):
     def required_predicates(self) -> List[Predicate]:
         return self._req_preds
 
+    def rebase_pass(self) -> BasePass:
+        return self._rebase_pass
+
     def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:
         assert optimisation_level in range(3)
         passes = [DecomposeBoxes()]
@@ -508,7 +512,7 @@ class BraketBackend(Backend):
             passes.append(SynthesiseTket())
         elif optimisation_level == 2:
             passes.append(FullPeepholeOptimise())
-        passes.append(self._rebase_pass)
+        passes.append(self.rebase_pass())
         if self._device_type == _DeviceType.QPU and self.characterisation is not None:
             arch = self.backend_info.architecture
             passes.append(
@@ -530,7 +534,7 @@ class BraketBackend(Backend):
                 [
                     CliffordSimp(False),
                     SynthesiseTket(),
-                    self._rebase_pass,
+                    self.rebase_pass(),
                     self._squash_pass,
                 ]
             )

--- a/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
+++ b/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
@@ -363,7 +363,6 @@ class BraketBackend(Backend):
             lambda a, b, c: Circuit(1).Rz(c, 0).Rx(b, 0).Rz(a, 0),
         )
 
-
     @staticmethod
     def _get_gate_set(
         supported_ops: Set[str], device_type: _DeviceType

--- a/modules/pytket-braket/setup.py
+++ b/modules/pytket-braket/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 0.19.0rc0", "amazon-braket-sdk ~= 1.0"],
+    install_requires=["pytket == 0.19.0rc1", "amazon-braket-sdk ~= 1.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-cirq/setup.py
+++ b/modules/pytket-cirq/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket == 0.19.0rc0",
+        "pytket == 0.19.0rc1",
         "cirq-core ~= 0.13.0",
         "cirq-google ~= 0.13.0",
     ],

--- a/modules/pytket-honeywell/pytket/extensions/honeywell/backends/honeywell.py
+++ b/modules/pytket-honeywell/pytket/extensions/honeywell/backends/honeywell.py
@@ -252,17 +252,20 @@ class HoneywellBackend(Backend):
 
         return preds
 
+    def rebase_pass(self) -> BasePass:
+        return RebaseHQS()
+
     def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:
         assert optimisation_level in range(3)
         passlist = [DecomposeClassicalExp(), DecomposeBoxes()]
         if optimisation_level == 0:
-            return SequencePass(passlist + [RebaseHQS()])
+            return SequencePass(passlist + [self.rebase_pass()])
         elif optimisation_level == 1:
             return SequencePass(
                 passlist
                 + [
                     SynthesiseTket(),
-                    RebaseHQS(),
+                    self.rebase_pass(),
                     RemoveRedundancies(),
                     SquashHQS(),
                     SimplifyInitial(
@@ -275,7 +278,7 @@ class HoneywellBackend(Backend):
                 passlist
                 + [
                     FullPeepholeOptimise(),
-                    RebaseHQS(),
+                    self.rebase_pass(),
                     RemoveRedundancies(),
                     SquashHQS(),
                     SimplifyInitial(

--- a/modules/pytket-honeywell/setup.py
+++ b/modules/pytket-honeywell/setup.py
@@ -38,7 +38,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket == 0.19.0rc0",
+        "pytket == 0.19.0rc1",
         "requests >= 2.2",
         "types-requests",
         "websockets >= 7.0",

--- a/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq.py
+++ b/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq.py
@@ -47,7 +47,7 @@ from pytket.predicates import (  # type: ignore
 )
 from pytket.utils import prepare_circuit
 from pytket.utils.outcomearray import OutcomeArray
-from .ionq_convert import ionq_pass, ionq_gates, ionq_singleqs, tk_to_ionq
+from .ionq_convert import ionq_rebase_pass, ionq_gates, ionq_singleqs, tk_to_ionq
 from .config import IonQConfig
 
 IONQ_JOBS_URL = "https://api.ionq.co/v0.1/jobs/"
@@ -151,6 +151,9 @@ class IonQBackend(Backend):
         ]
         return preds
 
+    def rebase_pass(self) -> BasePass:
+        return ionq_rebase_pass
+
     def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:
         assert optimisation_level in range(3)
         if optimisation_level == 0:
@@ -159,7 +162,7 @@ class IonQBackend(Backend):
                     DecomposeBoxes(),
                     FlattenRegisters(),
                     RenameQubitsPass(self._qm),
-                    ionq_pass,
+                    self.rebase_pass(),
                 ]
             )
         elif optimisation_level == 1:
@@ -169,7 +172,7 @@ class IonQBackend(Backend):
                     SynthesiseTket(),
                     FlattenRegisters(),
                     RenameQubitsPass(self._qm),
-                    ionq_pass,
+                    self.rebase_pass(),
                     SimplifyInitial(allow_classical=False, create_all_qubits=True),
                 ]
             )
@@ -180,7 +183,7 @@ class IonQBackend(Backend):
                     FullPeepholeOptimise(),
                     FlattenRegisters(),
                     RenameQubitsPass(self._qm),
-                    ionq_pass,
+                    self.rebase_pass(),
                     SquashCustom(
                         ionq_singleqs,
                         lambda a, b, c: Circuit(1).Rz(c, 0).Rx(b, 0).Rz(a, 0),

--- a/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq_convert.py
+++ b/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq_convert.py
@@ -55,7 +55,7 @@ ionq_singleqs = {
 
 ionq_gates = ionq_multiqs.union(ionq_singleqs)
 
-ionq_pass = RebaseCustom(
+ionq_rebase_pass = RebaseCustom(
     ionq_multiqs,
     Circuit(),  # cx_replacement (irrelevant)
     ionq_singleqs,  # singleqs

--- a/modules/pytket-ionq/setup.py
+++ b/modules/pytket-ionq/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 0.19.0rc0", "requests ~= 2.22", "types-requests"],
+    install_requires=["pytket == 0.19.0rc1", "requests ~= 2.22", "types-requests"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-iqm/pytket/extensions/iqm/backends/iqm.py
+++ b/modules/pytket-iqm/pytket/extensions/iqm/backends/iqm.py
@@ -164,18 +164,21 @@ class IQMBackend(Backend):
             ConnectivityPredicate(self._arch),
         ]
 
+    def rebase_pass(self) -> BasePass:
+        return _iqm_rebase()
+
     def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:
         assert optimisation_level in range(3)
         passes = [DecomposeBoxes(), FlattenRegisters()]
         if optimisation_level == 0:
-            passes.append(_iqm_rebase())  # to satisfy MaxTwoQubitGatesPredicate
+            passes.append(self.rebase_pass())  # to satisfy MaxTwoQubitGatesPredicate
         elif optimisation_level == 1:
             passes.append(SynthesiseTket())
         elif optimisation_level == 2:
             passes.append(FullPeepholeOptimise())
         passes.append(DefaultMappingPass(self._arch))
         passes.append(DelayMeasures())
-        passes.append(_iqm_rebase())
+        passes.append(self.rebase_pass())
         passes.append(RemoveRedundancies())
         if optimisation_level >= 1:
             passes.append(

--- a/modules/pytket-iqm/setup.py
+++ b/modules/pytket-iqm/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 0.19.0rc0", "iqm-client ~= 1.6"],
+    install_requires=["pytket == 0.19.0rc1", "iqm-client ~= 1.6"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.9",

--- a/modules/pytket-projectq/pytket/extensions/projectq/backends/projectq_backend.py
+++ b/modules/pytket-projectq/pytket/extensions/projectq/backends/projectq_backend.py
@@ -140,7 +140,7 @@ class ProjectQBackend(Backend):
         assert optimisation_level in range(3)
         if optimisation_level == 0:
             return SequencePass(
-                [DecomposeBoxes(), FlattenRegisters(), self.rebase_pass()()]
+                [DecomposeBoxes(), FlattenRegisters(), self.rebase_pass()]
             )
         elif optimisation_level == 1:
             return SequencePass(
@@ -148,7 +148,7 @@ class ProjectQBackend(Backend):
                     DecomposeBoxes(),
                     FlattenRegisters(),
                     SynthesiseTket(),
-                    self.rebase_pass()(),
+                    self.rebase_pass(),
                 ]
             )
         else:
@@ -157,7 +157,7 @@ class ProjectQBackend(Backend):
                     DecomposeBoxes(),
                     FlattenRegisters(),
                     FullPeepholeOptimise(),
-                    self.rebase_pass()(),
+                    self.rebase_pass(),
                 ]
             )
 

--- a/modules/pytket-projectq/pytket/extensions/projectq/backends/projectq_backend.py
+++ b/modules/pytket-projectq/pytket/extensions/projectq/backends/projectq_backend.py
@@ -133,11 +133,14 @@ class ProjectQBackend(Backend):
             DefaultRegisterPredicate(),
         ]
 
+    def rebase_pass(self) -> BasePass:
+        return RebaseProjectQ()
+
     def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:
         assert optimisation_level in range(3)
         if optimisation_level == 0:
             return SequencePass(
-                [DecomposeBoxes(), FlattenRegisters(), RebaseProjectQ()]
+                [DecomposeBoxes(), FlattenRegisters(), self.rebase_pass()()]
             )
         elif optimisation_level == 1:
             return SequencePass(
@@ -145,7 +148,7 @@ class ProjectQBackend(Backend):
                     DecomposeBoxes(),
                     FlattenRegisters(),
                     SynthesiseTket(),
-                    RebaseProjectQ(),
+                    self.rebase_pass()(),
                 ]
             )
         else:
@@ -154,7 +157,7 @@ class ProjectQBackend(Backend):
                     DecomposeBoxes(),
                     FlattenRegisters(),
                     FullPeepholeOptimise(),
-                    RebaseProjectQ(),
+                    self.rebase_pass()(),
                 ]
             )
 

--- a/modules/pytket-projectq/setup.py
+++ b/modules/pytket-projectq/setup.py
@@ -38,7 +38,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 0.19.0rc0", "projectq ~= 0.7.0"],
+    install_requires=["pytket == 0.19.0rc1", "projectq ~= 0.7.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
+++ b/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
@@ -125,6 +125,9 @@ class ForestBackend(Backend):
             ConnectivityPredicate(self.backend_info.architecture),
         ]
 
+    def rebase_pass(self) -> BasePass:
+        return RebaseQuil()
+
     def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:
         assert optimisation_level in range(3)
         passlist = [
@@ -151,7 +154,7 @@ class ForestBackend(Backend):
             passlist.append(CliffordSimp(False))
         if optimisation_level > 0:
             passlist.append(SynthesiseTket())
-        passlist.append(RebaseQuil())
+        passlist.append(self.rebase_pass())
         if optimisation_level > 0:
             passlist.extend(
                 [
@@ -335,6 +338,9 @@ class ForestStateBackend(Backend):
             DefaultRegisterPredicate(),
         ]
 
+    def rebase_pass(self) -> BasePass:
+        return RebaseQuil()
+
     def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:
         assert optimisation_level in range(3)
         passlist = [DecomposeBoxes(), FlattenRegisters()]
@@ -342,7 +348,7 @@ class ForestStateBackend(Backend):
             passlist.append(SynthesiseTket())
         elif optimisation_level == 2:
             passlist.append(FullPeepholeOptimise())
-        passlist.append(RebaseQuil())
+        passlist.append(self.rebase_pass())
         if optimisation_level > 0:
             passlist.append(EulerAngleReduction(OpType.Rx, OpType.Rz))
         return SequencePass(passlist)

--- a/modules/pytket-pyquil/setup.py
+++ b/modules/pytket-pyquil/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket == 0.19.0rc0",
+        "pytket == 0.19.0rc1",
         "pyquil ~= 3.0",
         "typing-extensions ~= 3.7",
     ],

--- a/modules/pytket-pyzx/setup.py
+++ b/modules/pytket-pyzx/setup.py
@@ -38,7 +38,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 0.19.0rc0", "pyzx ~= 0.6.3"],
+    install_requires=["pytket == 0.19.0rc1", "pyzx ~= 0.6.3"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
@@ -110,36 +110,29 @@ class _AerBaseBackend(Backend):
         super().__init__()
         self._backend: "QiskitAerBackend" = Aer.get_backend(backend_name)
 
-        gate_set: Set[OpType] = {
+        self._gate_set: Set[OpType] = {
             _gate_str_2_optype[gate_str]
             for gate_str in self._backend.configuration().basis_gates
             if gate_str in _gate_str_2_optype
         }
         # special case mapping TK1 to U
-        gate_set.add(OpType.TK1)
-        if not gate_set >= _required_gates:
+        self._gate_set.add(OpType.TK1)
+        if not self._gate_set >= _required_gates:
             raise NotImplementedError(
-                f"Gate set {gate_set} missing at least one of {_required_gates}"
+                f"Gate set {self._gate_set} missing at least one of {_required_gates}"
             )
         self._backend_info = BackendInfo(
             type(self).__name__,
             backend_name,
             __extension_version__,
             Architecture([]),
-            gate_set,
+            self._gate_set,
             supports_midcircuit_measurement=True,  # is this correct?
             misc={"characterisation": None},
         )
 
         self._memory = False
         self._noise_model: Optional[NoiseModel] = None
-
-        self._rebase_pass = RebaseCustom(
-            gate_set & _2q_gates,
-            Circuit(2).CX(0, 1),
-            gate_set & _1q_gates,
-            _tk1_to_u,
-        )
 
     @property
     def _result_id_type(self) -> _ResultIdTuple:
@@ -153,6 +146,14 @@ class _AerBaseBackend(Backend):
     @property
     def backend_info(self) -> BackendInfo:
         return self._backend_info
+
+    def rebase_pass(self) -> BasePass:
+        return RebaseCustom(
+            self._gate_set & _2q_gates,
+            Circuit(2).CX(0, 1),
+            self._gate_set & _1q_gates,
+            _tk1_to_u,
+        )
 
     def process_circuits(
         self,
@@ -328,7 +329,7 @@ class _AerStateBaseBackend(_AerBaseBackend):
     def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:
         assert optimisation_level in range(3)
         if optimisation_level == 0:
-            return SequencePass([DecomposeBoxes(), self._rebase_pass])
+            return SequencePass([DecomposeBoxes(), self.rebase_pass()])
         elif optimisation_level == 1:
             return SequencePass([DecomposeBoxes(), SynthesiseTket()])
         else:
@@ -484,7 +485,7 @@ class AerBackend(_AerBaseBackend):
         assert optimisation_level in range(3)
         passlist = [DecomposeBoxes()]
         if optimisation_level == 0:
-            passlist.append(self._rebase_pass)
+            passlist.append(self.rebase_pass())
         elif optimisation_level == 1:
             passlist.append(SynthesiseTket())
         else:
@@ -506,7 +507,7 @@ class AerBackend(_AerBaseBackend):
                 )
             )
             if optimisation_level == 0:
-                passlist.append(self._rebase_pass)
+                passlist.append(self.rebase_pass())
             elif optimisation_level == 1:
                 passlist.append(SynthesiseTket())
             else:

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibm.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibm.py
@@ -195,14 +195,6 @@ def _tk1_to_x_sx_rz(
     return circ
 
 
-_rebase_pass = RebaseCustom(
-    {OpType.CX},
-    Circuit(2).CX(0, 1),
-    {OpType.X, OpType.SX, OpType.Rz},
-    _tk1_to_x_sx_rz,
-)
-
-
 class IBMQBackend(Backend):
     _supports_shots = True
     _supports_counts = True
@@ -404,7 +396,7 @@ class IBMQBackend(Backend):
         passlist = [DecomposeBoxes()]
         if optimisation_level == 0:
             if self._standard_gateset:
-                passlist.append(_rebase_pass)
+                passlist.append(self.rebase_pass())
         elif optimisation_level == 1:
             passlist.append(SynthesiseTket())
         elif optimisation_level == 2:
@@ -430,7 +422,7 @@ class IBMQBackend(Backend):
         if optimisation_level == 2:
             passlist.extend([CliffordSimp(False), SynthesiseTket()])
         if self._standard_gateset:
-            passlist.extend([_rebase_pass, RemoveRedundancies()])
+            passlist.extend([self.rebase_pass(), RemoveRedundancies()])
         if optimisation_level > 0:
             passlist.append(
                 SimplifyInitial(allow_classical=False, create_all_qubits=True)
@@ -440,6 +432,14 @@ class IBMQBackend(Backend):
     @property
     def _result_id_type(self) -> _ResultIdTuple:
         return (str, int, str)
+
+    def rebase_pass(self) -> BasePass:
+        return RebaseCustom(
+            {OpType.CX},
+            Circuit(2).CX(0, 1),
+            {OpType.X, OpType.SX, OpType.Rz},
+            _tk1_to_x_sx_rz,
+        )
 
     def process_circuits(
         self,

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
@@ -136,7 +136,7 @@ _qiskit_gates_other = {
     # Special types:
     Barrier: OpType.Barrier,
     Instruction: OpType.CircBox,
-    Gate: OpType.Custom,
+    Gate: OpType.CustomGate,
     Measure: OpType.Measure,
     Reset: OpType.Reset,
     UnitaryGate: OpType.Unitary2qBox,
@@ -305,7 +305,7 @@ class CircuitBuilder:
                 self.tkc.add_circbox(ccbox, qubits)
             elif optype == OpType.Barrier:
                 self.tkc.add_barrier(qubits)
-            elif optype in (OpType.CircBox, OpType.Custom):
+            elif optype in (OpType.CircBox, OpType.CustomGate):
                 qregs = [QuantumRegister(i.num_qubits, "q")] if i.num_qubits > 0 else []
                 cregs = (
                     [ClassicalRegister(i.num_clbits, "c")] if i.num_clbits > 0 else []
@@ -418,7 +418,7 @@ def append_tk_command_to_qiskit(
         qb = qregmap[args[0].reg_name][args[0].index[0]]
         return qcirc.reset(qb)
 
-    if optype in [OpType.CircBox, OpType.ExpBox, OpType.PauliExpBox, OpType.Custom]:
+    if optype in [OpType.CircBox, OpType.ExpBox, OpType.PauliExpBox, OpType.CustomGate]:
         subcircuit = op.get_circuit()
         subqc = tk_to_qiskit(subcircuit)
         qargs = []
@@ -428,7 +428,7 @@ def append_tk_command_to_qiskit(
                 qargs.append(qregmap[a.reg_name][a.index[0]])
             else:
                 cargs.append(cregmap[a.reg_name][a.index[0]])
-        if optype == OpType.Custom:
+        if optype == OpType.CustomGate:
             instruc = subqc.to_gate()
             instruc.name = op.get_name()
         else:
@@ -450,7 +450,7 @@ def append_tk_command_to_qiskit(
         # attach predicate to bit,
         # subsequent conditional will handle it
         return Instruction("", 0, 0, [])
-    if optype == OpType.ConditionalGate:
+    if optype == OpType.Conditional:
         if args[0] in range_preds:
             assert op.value == 1
             condition_bits, value = range_preds[args[0]]

--- a/modules/pytket-qiskit/setup.py
+++ b/modules/pytket-qiskit/setup.py
@@ -38,7 +38,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 0.19.0rc0", "qiskit ~= 0.33.0"],
+    install_requires=["pytket == 0.19.0rc1", "qiskit ~= 0.33.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-qiskit/tests/backend_test.py
+++ b/modules/pytket-qiskit/tests/backend_test.py
@@ -41,7 +41,6 @@ from pytket.extensions.qiskit import (
     AerUnitaryBackend,
     IBMQEmulatorBackend,
 )
-from pytket.extensions.qiskit.backends.ibm import _rebase_pass
 from pytket.extensions.qiskit import qiskit_to_tk, process_characterisation
 from pytket.utils.expectations import (
     get_pauli_expectation_value,
@@ -983,7 +982,7 @@ def test_symbolic_rebase() -> None:
     pytket_circ = qiskit_to_tk(circ)
 
     # rebase pass could not handle symbolic parameters originally and would fail here:
-    _rebase_pass.apply(pytket_circ)
+    AerBackend().rebase_pass().apply(pytket_circ)
 
     assert len(pytket_circ.free_symbols()) == 2
 
@@ -1003,7 +1002,7 @@ def _verify_single_q_rebase(
     u_before = backend.run_circuit(rotation_circ).get_unitary()
     circ = Circuit(1)
     circ.add_gate(OpType.TK1, [a, b, c], [0])
-    _rebase_pass.apply(circ)
+    backend.rebase_pass().apply(circ)
     u_after = backend.run_circuit(circ).get_unitary()
     return np.allclose(u_before, u_after)
 

--- a/modules/pytket-qsharp/setup.py
+++ b/modules/pytket-qsharp/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket == 0.19.0rc0",
+        "pytket == 0.19.0rc1",
         "qsharp ~= 0.21.2111",
         "qsharp-core ~= 0.21.2111",
     ],

--- a/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
+++ b/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
@@ -116,12 +116,6 @@ class QulacsBackend(Backend):
         )
 
         self._sim = QuantumState
-        self._rebase_pass = RebaseCustom(
-            set(_TWO_QUBIT_GATES),
-            Circuit(2).CX(0, 1),
-            _1Q_GATES,
-            _tk1_to_u,
-        )
 
     @property
     def _result_id_type(self) -> _ResultIdTuple:
@@ -142,11 +136,19 @@ class QulacsBackend(Backend):
             DefaultRegisterPredicate(),
         ]
 
+    def rebase_pass(self) -> BasePass:
+        return RebaseCustom(
+            set(_TWO_QUBIT_GATES),
+            Circuit(2).CX(0, 1),
+            _1Q_GATES,
+            _tk1_to_u,
+        )
+
     def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:
         assert optimisation_level in range(3)
         if optimisation_level == 0:
             return SequencePass(
-                [DecomposeBoxes(), FlattenRegisters(), self._rebase_pass]
+                [DecomposeBoxes(), FlattenRegisters(), self.rebase_pass()]
             )
         elif optimisation_level == 1:
             return SequencePass(
@@ -154,7 +156,7 @@ class QulacsBackend(Backend):
                     DecomposeBoxes(),
                     FlattenRegisters(),
                     SynthesiseTket(),
-                    self._rebase_pass,
+                    self.rebase_pass(),
                 ]
             )
         else:
@@ -163,7 +165,7 @@ class QulacsBackend(Backend):
                     DecomposeBoxes(),
                     FlattenRegisters(),
                     FullPeepholeOptimise(),
-                    self._rebase_pass,
+                    self.rebase_pass(),
                 ]
             )
 

--- a/modules/pytket-qulacs/setup.py
+++ b/modules/pytket-qulacs/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 0.19.0rc0", "Qulacs ~= 0.3.0"],
+    install_requires=["pytket == 0.19.0rc1", "Qulacs ~= 0.3.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-stim/pytket/extensions/stim/backends/stim_backend.py
+++ b/modules/pytket-stim/pytket/extensions/stim/backends/stim_backend.py
@@ -130,15 +130,16 @@ class StimBackend(Backend):
             NoClassicalControlPredicate(),
         ]
 
+    def rebase_pass(self) -> BasePass:
+        return RebaseCustom({OpType.CX}, Circuit(), {OpType.H, OpType.S}, _tk1_to_cliff)
+
     def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:
         # No optimization.
         return SequencePass(
             [
                 DecomposeBoxes(),
                 FlattenRegisters(),
-                RebaseCustom(
-                    {OpType.CX}, Circuit(), {OpType.H, OpType.S}, _tk1_to_cliff
-                ),
+                self.rebase_pass(),
                 RemoveRedundancies(),
             ]
         )

--- a/modules/pytket-stim/setup.py
+++ b/modules/pytket-stim/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 0.19.0rc0", "stim ~= 1.4"],
+    install_requires=["pytket == 0.19.0rc1", "stim ~= 1.4"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
A consistent part of compiling to different hardware is rebasing a circuit i.e. rewriting each gate in a circuit so that is a (sequence) of gates with OpType permitted by the hardware.

Currently this is completed inconsistently across all Backend. Each Backend now has a `rebase_pass` method which returns a `BasePass` object for applying to a Circuit to complete this transformation. This is also a new abstractmethod of the base `Backend` class. 