### PR TITLE
[pytket-qsharp] Update to qsharp 0.22.

### DIFF
--- a/modules/pytket-qsharp/_metadata.py
+++ b/modules/pytket-qsharp/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.20.0"
+__extension_version__ = "0.21.0"
 __extension_name__ = "pytket-qsharp"

--- a/modules/pytket-qsharp/docs/changelog.rst
+++ b/modules/pytket-qsharp/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+0.21.0 (unreleased)
+-------------------
+
+* Updated qsharp version requirement to 0.22.
+
 0.20.0 (January 2022)
 ---------------------
 

--- a/modules/pytket-qsharp/setup.py
+++ b/modules/pytket-qsharp/setup.py
@@ -40,8 +40,8 @@ setup(
     include_package_data=True,
     install_requires=[
         "pytket == 0.19.0rc1",
-        "qsharp ~= 0.21.2111",
-        "qsharp-core ~= 0.21.2111",
+        "qsharp ~= 0.22.186910",
+        "qsharp-core ~= 0.22.186910",
     ],
     classifiers=[
         "Environment :: Console",


### PR DESCRIPTION
I checked to see if #180 or #268 were fixed. Neither is. (The problem for both seems to be qsharp's dependence on an old version of pyzmq.)