### PR TITLE
Publish wheels to pypi from hotfix workflow

### DIFF
--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -62,3 +62,26 @@ jobs:
       with:
         name: artefacts
         path: wheelhouse/
+
+  publish_to_pypi:
+    name: Publish to pypi
+    if: contains(github.event.head_commit.message, 'hotfix')
+    needs: generate
+    runs-on: ubuntu-20.04
+
+    steps:
+
+    - name: Download all wheels
+      uses: actions/download-artifact@v2
+      with:
+        path: wheelhouse
+    - name: Put them all in the dist folder
+      run: |
+        mkdir dist
+        for w in `find wheelhouse/ -type f -name "*.tar.gz"` ; do cp $w dist/ ; done
+    - name: Publish wheels
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_EXTENSIONS_API_TOKEN }}
+        verbose: true


### PR DESCRIPTION
Basically copy-and-pasted from `build_and_test.yml`. (Maybe in future we could combine the YAML files into one.)