### PR TITLE
[TKET-1767] Cast the dict type to avoid error while running to_dict on BackendInfo.

### DIFF
--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
@@ -450,7 +450,7 @@ class AerBackend(_AerBaseBackend):
             arch = characterisation["Architecture"]
             # filter entries to keep
             characterisation = {
-                k: v for k, v in characterisation.items() if k in characterisation_keys
+                k: dict(v) for k, v in characterisation.items() if k in characterisation_keys
             }
             self._backend_info.misc["characterisation"] = characterisation
 

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
@@ -450,7 +450,9 @@ class AerBackend(_AerBaseBackend):
             arch = characterisation["Architecture"]
             # filter entries to keep
             characterisation = {
-                k: dict(v) for k, v in characterisation.items() if k in characterisation_keys
+                k: dict(v)
+                for k, v in characterisation.items()
+                if k in characterisation_keys
             }
             self._backend_info.misc["characterisation"] = characterisation
 


### PR DESCRIPTION
Fixes [TKET-1767](https://cqc.atlassian.net/browse/TKET-1767?atlOrigin=eyJpIjoiOWY1ODIyYzM3NjAyNDFiNmEyMjFkYjFkODI0MjBmOTUiLCJwIjoiaiJ9).

This PR addresses the returned error while running `to_dict()` on the underlying `BackendInfo`. It originates from the `characterisation` [keys](https://github.com/CQCL/pytket-extensions/blob/eebdaf261cb99d4cfc7d4622aa708bd6b26aea19/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py#L446)  returning a `defaultdict` type which errors the `asdict` from `dataclasses`. 

Bug fix: Cast the `dict` type when filtering `characterisation` keys to keep [here](https://github.com/CQCL/pytket-extensions/blob/eebdaf261cb99d4cfc7d4622aa708bd6b26aea19/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py#L452). 