### PR TITLE
Update IBMQEmulatorBackend.rebase_pass

### DIFF
--- a/modules/pytket-qiskit/docs/changelog.rst
+++ b/modules/pytket-qiskit/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+0.22.1 (February 2022)
+----------------------
+
+* Added :py:meth:`IBMQEmulatorBackend.rebase_pass`.
+
 0.22.0 (February 2022)
 ----------------------
 

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -34,7 +34,6 @@ from pytket.extensions.qiskit.qiskit_convert import tk_to_qiskit
 from pytket.extensions.qiskit.result_convert import (
     qiskit_experimentresult_to_backendresult,
 )
-from pytket.passes import BasePass  # type: ignore
 from pytket.utils import prepare_circuit
 from pytket.utils.results import KwargTypes
 
@@ -47,6 +46,7 @@ from .ibm_utils import _batch_circuits
 
 if TYPE_CHECKING:
     from pytket.predicates import Predicate  # type: ignore
+    from pytket.passes import BasePass  # type: ignore
     from qiskit.providers.aer import AerJob  # type: ignore
     from qiskit.providers.ibmq import AccountProvider  # type: ignore
     from qiskit.result.models import ExperimentResult  # type: ignore
@@ -100,7 +100,7 @@ class IBMQEmulatorBackend(AerBackend):
     def backend_info(self) -> BackendInfo:
         return self._ibmq.backend_info
 
-    def rebase_pass(self) -> BasePass:
+    def rebase_pass(self) -> "BasePass":
         return self._ibmq.rebase_pass
 
     @property

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -100,6 +100,9 @@ class IBMQEmulatorBackend(AerBackend):
     def backend_info(self) -> BackendInfo:
         return self._ibmq.backend_info
 
+    def rebase_pass(self) -> BasePass:
+        return self._ibmq.rebase_pass
+
     @property
     def required_predicates(self) -> List["Predicate"]:
         return list(self._ibmq.required_predicates)

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -34,6 +34,7 @@ from pytket.extensions.qiskit.qiskit_convert import tk_to_qiskit
 from pytket.extensions.qiskit.result_convert import (
     qiskit_experimentresult_to_backendresult,
 )
+from pytket.passes import BasePass  # type: ignore
 from pytket.utils import prepare_circuit
 from pytket.utils.results import KwargTypes
 
@@ -46,7 +47,6 @@ from .ibm_utils import _batch_circuits
 
 if TYPE_CHECKING:
     from pytket.predicates import Predicate  # type: ignore
-    from pytket.passes import BasePass  # type: ignore
     from qiskit.providers.aer import AerJob  # type: ignore
     from qiskit.providers.ibmq import AccountProvider  # type: ignore
     from qiskit.result.models import ExperimentResult  # type: ignore

--- a/modules/pytket-qiskit/tests/backend_test.py
+++ b/modules/pytket-qiskit/tests/backend_test.py
@@ -812,6 +812,9 @@ def test_ibmq_emulator() -> None:
             assert not all(pred.verify(c_cop_2) for pred in b_emu.required_predicates)
 
     circ = Circuit(2, 2).H(0).CX(0, 1).measure_all()
+    copy_circ = circ.copy()
+    b_emu.rebase_pass().apply(copy_circ)
+    assert b_emu.required_predicates[1].verify(copy_circ)
     circ = b_emu.get_compiled_circuit(circ)
     b_noi = AerBackend(noise_model=b_emu._noise_model)
     emu_shots = b_emu.run_circuit(circ, n_shots=10, seed=10).get_shots()


### PR DESCRIPTION
`IBMQEmulatorBackend` inherits from `AerBackend`, meaning it inherits `AerBackend.rebase_pass` which supports a set of gates that does not match `IBMQEmulatorBackend.required_predicates`.
Note that `IBMQEmulatorBackend.default_compilation_pass` & `IBMQEmulatorBackend.compile_circuit` still support valid circuits as they manually reassign these methods from a generated `IBMQBackend` object.