### PR TITLE
[bugfix] update rebases and squash to new pytket API

### DIFF
--- a/modules/pytket-aqt/pytket/extensions/aqt/backends/aqt.py
+++ b/modules/pytket-aqt/pytket/extensions/aqt/backends/aqt.py
@@ -39,6 +39,7 @@ from pytket.passes import (  # type: ignore
     DecomposeBoxes,
     RenameQubitsPass,
     SimplifyInitial,
+    auto_rebase_pass,
 )
 from pytket.predicates import (  # type: ignore
     GateSetPredicate,
@@ -376,19 +377,8 @@ def _translate_aqt(circ: Circuit) -> Tuple[List[List], str]:
     return (gates, json.dumps(measures))
 
 
-def _aqt_rebase() -> BasePass:
-    # CX replacement
-    c_cx = Circuit(2)
-    c_cx.Ry(0.5, 0).Rx(0.5, 0)
-    c_cx.Rx(-0.5, 1)
-    c_cx.add_gate(OpType.XXPhase, 0.5, [0, 1])
-    c_cx.Ry(0.5, 0).Rx(-1, 0)
-    c_cx.add_phase(-0.25)
-
-    # TK1 replacement
-    c_tk1 = lambda a, b, c: Circuit(1).Rx(-0.5, 0).Ry(c, 0).Rx(b, 0).Ry(a, 0).Rx(0.5, 0)
-
-    return RebaseCustom({OpType.XXPhase}, c_cx, {OpType.Rx, OpType.Ry}, c_tk1)
+def _aqt_rebase() -> RebaseCustom:
+    return auto_rebase_pass({OpType.XXPhase, OpType.Rx, OpType.Ry})
 
 
 _xcirc = Circuit(1).Rx(1, 0)

--- a/modules/pytket-aqt/setup.py
+++ b/modules/pytket-aqt/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.0.0rc0", "requests ~= 2.22", "types-requests"],
+    install_requires=["pytket == 1.0.0rc8", "requests ~= 2.22", "types-requests"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
+++ b/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
@@ -55,6 +55,7 @@ from pytket.passes import (  # type: ignore
     DecomposeBoxes,
     SimplifyInitial,
 )
+from pytket._tket.circuit._library import _TK1_to_RzRx  # type: ignore
 from pytket.pauli import Pauli, QubitPauliString  # type: ignore
 from pytket.predicates import (  # type: ignore
     ConnectivityPredicate,
@@ -355,14 +356,13 @@ class BraketBackend(Backend):
             self._req_preds.append(ConnectivityPredicate(arch))
 
         self._rebase_pass = RebaseCustom(
-            self._multiqs,
+            self._multiqs | self._singleqs,
             Circuit(),
-            self._singleqs,
-            lambda a, b, c: Circuit(1).Rz(c, 0).Rx(b, 0).Rz(a, 0),
+            _TK1_to_RzRx,
         )
         self._squash_pass = SquashCustom(
             self._singleqs,
-            lambda a, b, c: Circuit(1).Rz(c, 0).Rx(b, 0).Rz(a, 0),
+            _TK1_to_RzRx,
         )
 
     @staticmethod

--- a/modules/pytket-braket/setup.py
+++ b/modules/pytket-braket/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.0.0rc0", "amazon-braket-sdk ~= 1.0"],
+    install_requires=["pytket == 1.0.0rc8", "amazon-braket-sdk ~= 1.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-cirq/setup.py
+++ b/modules/pytket-cirq/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket == 1.0.0rc0",
+        "pytket == 1.0.0rc8",
         "cirq-core ~= 0.13.0",
         "cirq-google ~= 0.13.0",
     ],

--- a/modules/pytket-honeywell/setup.py
+++ b/modules/pytket-honeywell/setup.py
@@ -38,7 +38,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket == 1.0.0rc0",
+        "pytket == 1.0.0rc8",
         "requests >= 2.2",
         "types-requests",
         "websockets >= 7.0",

--- a/modules/pytket-honeywell/tests/convert_test.py
+++ b/modules/pytket-honeywell/tests/convert_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from pytket.circuit import Circuit, OpType  # type: ignore
-from pytket.passes import RebaseHQS  # type: ignore
+from pytket.extensions.honeywell import HoneywellBackend
 from pytket.qasm import circuit_to_qasm_str
 
 
@@ -26,7 +26,7 @@ def test_convert() -> None:
     circ.ZZPhase(0.3, 2, 3).CX(3, 0).Tdg(1)
     circ.measure_all()
 
-    RebaseHQS().apply(circ)
+    HoneywellBackend("", login=False, machine_debug=True).rebase_pass().apply(circ)
     circ_hqs = circuit_to_qasm_str(circ, header="hqslib1")
     qasm_str = circ_hqs.split("\n")[6:-1]
     test = True

--- a/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq.py
+++ b/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq.py
@@ -36,6 +36,7 @@ from pytket.passes import (  # type: ignore
     RenameQubitsPass,
     SimplifyInitial,
 )
+from pytket._tket.circuit._library import _TK1_to_RzRx  # type: ignore
 from pytket.predicates import (  # type: ignore
     GateSetPredicate,
     MaxNQubitsPredicate,
@@ -186,7 +187,7 @@ class IonQBackend(Backend):
                     self.rebase_pass(),
                     SquashCustom(
                         ionq_singleqs,
-                        lambda a, b, c: Circuit(1).Rz(c, 0).Rx(b, 0).Rz(a, 0),
+                        _TK1_to_RzRx,
                     ),
                     SimplifyInitial(allow_classical=False, create_all_qubits=True),
                 ]

--- a/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq_convert.py
+++ b/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq_convert.py
@@ -14,16 +14,9 @@
 
 from typing import Dict, Tuple, Any, List
 from pytket.passes import RebaseCustom  # type: ignore
+from pytket._tket.circuit._library import _TK1_to_RzRx  # type: ignore
 from pytket.circuit import Circuit, OpType, Command  # type: ignore
 from numpy import pi
-
-
-def _from_tk1(a: float, b: float, c: float) -> Circuit:
-    circ = Circuit(1)
-    circ.Rz(c, 0)
-    circ.Rx(b, 0)
-    circ.Rz(a, 0)
-    return circ
 
 
 ionq_multiqs = {
@@ -56,10 +49,9 @@ ionq_singleqs = {
 ionq_gates = ionq_multiqs.union(ionq_singleqs)
 
 ionq_rebase_pass = RebaseCustom(
-    ionq_multiqs,
+    ionq_multiqs | ionq_singleqs,
     Circuit(),  # cx_replacement (irrelevant)
-    ionq_singleqs,  # singleqs
-    _from_tk1,
+    _TK1_to_RzRx,
 )  # tk1_replacement
 
 ionq_gate_dict = {

--- a/modules/pytket-ionq/setup.py
+++ b/modules/pytket-ionq/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.0.0rc0", "requests ~= 2.22", "types-requests"],
+    install_requires=["pytket == 1.0.0rc8", "requests ~= 2.22", "types-requests"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-iqm/pytket/extensions/iqm/backends/iqm.py
+++ b/modules/pytket-iqm/pytket/extensions/iqm/backends/iqm.py
@@ -343,7 +343,7 @@ def _iqm_rebase() -> BasePass:
         .add_gate(OpType.PhasedX, [1 + b, a], [0])
     )
 
-    return RebaseCustom({OpType.CZ}, c_cx, {OpType.PhasedX}, c_tk1)
+    return RebaseCustom({OpType.CZ, OpType.PhasedX}, c_cx, c_tk1)
 
 
 _xcirc = Circuit(1).add_gate(OpType.PhasedX, [1, 0], [0]).add_phase(0.5)

--- a/modules/pytket-iqm/setup.py
+++ b/modules/pytket-iqm/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.0.0rc0", "iqm-client ~= 1.6"],
+    install_requires=["pytket == 1.0.0rc8", "iqm-client ~= 1.6"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.9",

--- a/modules/pytket-projectq/pytket/extensions/projectq/backends/projectq_backend.py
+++ b/modules/pytket-projectq/pytket/extensions/projectq/backends/projectq_backend.py
@@ -45,7 +45,6 @@ from pytket.backends.resulthandle import _ResultIdTuple
 from pytket.backends.backendresult import BackendResult
 from pytket.passes import (  # type: ignore
     BasePass,
-    RebaseProjectQ,
     SequencePass,
     SynthesiseTket,
     FullPeepholeOptimise,
@@ -63,7 +62,7 @@ from pytket.predicates import (  # type: ignore
     Predicate,
 )
 from pytket.routing import Architecture  # type: ignore
-from pytket.extensions.projectq.projectq_convert import tk_to_projectq  # type: ignore
+from pytket.extensions.projectq.projectq_convert import tk_to_projectq, _REBASE  # type: ignore
 from pytket.extensions.projectq._metadata import __extension_version__  # type: ignore
 from pytket.utils.operators import QubitPauliOperator
 from pytket.utils.results import KwargTypes
@@ -134,7 +133,7 @@ class ProjectQBackend(Backend):
         ]
 
     def rebase_pass(self) -> BasePass:
-        return RebaseProjectQ()
+        return _REBASE
 
     def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:
         assert optimisation_level in range(3)

--- a/modules/pytket-projectq/setup.py
+++ b/modules/pytket-projectq/setup.py
@@ -38,7 +38,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.0.0rc0", "projectq ~= 0.7.0"],
+    install_requires=["pytket == 1.0.0rc8", "projectq ~= 0.7.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
+++ b/modules/pytket-pyquil/pytket/extensions/pyquil/backends/forest.py
@@ -45,7 +45,7 @@ from pytket.passes import (  # type: ignore
     BasePass,
     EulerAngleReduction,
     CXMappingPass,
-    RebaseQuil,
+    auto_rebase_pass,
     SequencePass,
     SynthesiseTket,
     DecomposeBoxes,
@@ -126,7 +126,7 @@ class ForestBackend(Backend):
         ]
 
     def rebase_pass(self) -> BasePass:
-        return RebaseQuil()
+        return auto_rebase_pass({OpType.CZ, OpType.Rz, OpType.Rx})
 
     def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:
         assert optimisation_level in range(3)
@@ -339,7 +339,7 @@ class ForestStateBackend(Backend):
         ]
 
     def rebase_pass(self) -> BasePass:
-        return RebaseQuil()
+        return auto_rebase_pass({OpType.CZ, OpType.Rz, OpType.Rx})
 
     def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:
         assert optimisation_level in range(3)

--- a/modules/pytket-pyquil/setup.py
+++ b/modules/pytket-pyquil/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket == 1.0.0rc0",
+        "pytket == 1.0.0rc8",
         "pyquil ~= 3.0",
         "typing-extensions ~= 3.7",
     ],

--- a/modules/pytket-pyzx/setup.py
+++ b/modules/pytket-pyzx/setup.py
@@ -38,7 +38,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.0.0rc0", "pyzx ~= 0.6.3"],
+    install_requires=["pytket == 1.0.0rc8", "pyzx ~= 0.6.3"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibm.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibm.py
@@ -29,7 +29,6 @@ from typing import (
 )
 from warnings import warn
 
-from sympy import Expr  # type: ignore
 import qiskit  # type: ignore
 from qiskit import IBMQ
 from qiskit.qobj import QobjExperimentHeader  # type: ignore
@@ -51,7 +50,7 @@ from pytket.extensions.qiskit.qiskit_convert import (
 from pytket.extensions.qiskit._metadata import __extension_version__
 from pytket.passes import (  # type: ignore
     BasePass,
-    RebaseCustom,
+    auto_rebase_pass,
     RemoveRedundancies,
     SequencePass,
     SynthesiseTket,
@@ -123,76 +122,6 @@ class NoIBMQAccountError(Exception):
             "No IBMQ credentials found on disk, store your account using qiskit,"
             " or using :py:meth:`pytket.extensions.qiskit.set_ibmq_config` first."
         )
-
-
-def _approx_0_mod_2(x: Union[float, Expr], eps: float = 1e-10) -> bool:
-    if isinstance(x, Expr) and not x.is_constant():
-        return False
-    x = float(x)
-    x %= 2
-    return min(x, 2 - x) < eps
-
-
-def int_half(angle: float) -> int:
-    # assume float is approximately an even integer, and return the half
-    two_x = round(angle)
-    assert not two_x % 2
-    return two_x // 2
-
-
-def _tk1_to_x_sx_rz(
-    a: Union[float, Expr], b: Union[float, Expr], c: Union[float, Expr]
-) -> Circuit:
-    circ = Circuit(1)
-    correction_phase = 0.0
-
-    # all phase identities use, for integer k,
-    # Rx(2k) = Rz(2k) = (-1)^{k}I
-
-    # _approx_0_mod_2 checks if parameters are constant
-    # so they can be assumed to be constant
-    if _approx_0_mod_2(b):
-        circ.Rz(a + c, 0)
-        # b = 2k, if k is odd, then Rx(b) = -I
-        correction_phase += int_half(float(b))
-
-    elif _approx_0_mod_2(b + 1):
-        # Use Rx(2k-1) = i(-1)^{k}X
-        correction_phase += -0.5 + int_half(float(b) - 1)
-        if _approx_0_mod_2(a - c):
-            circ.X(0)
-            # a - c = 2m
-            # overall operation is (-1)^{m}Rx(2k -1)
-            correction_phase += int_half(float(a - c))
-
-        else:
-            circ.Rz(c, 0).X(0).Rz(a, 0)
-
-    elif _approx_0_mod_2(b - 0.5) and _approx_0_mod_2(a) and _approx_0_mod_2(c):
-        # a = 2k, b = 2m+0.5, c = 2n
-        # Rz(2k)Rx(2m + 0.5)Rz(2n) = (-1)^{k+m+n}e^{-i \pi /4} SX
-        circ.SX(0)
-        correction_phase += (
-            int_half(float(b) - 0.5) + int_half(float(a)) + int_half(float(c)) - 0.25
-        )
-
-    elif _approx_0_mod_2(b + 0.5) and _approx_0_mod_2(a) and _approx_0_mod_2(c):
-        # a = 2k, b = 2m-0.5, c = 2n
-        # Rz(2k)Rx(2m - 0.5)Rz(2n) = (-1)^{k+m+n}e^{i \pi /4} X.SX
-        circ.X(0).SX(0)
-        correction_phase += (
-            int_half(float(b) + 0.5) + int_half(float(a)) + int_half(float(c)) + 0.25
-        )
-    elif _approx_0_mod_2(a - 0.5) and _approx_0_mod_2(c - 0.5):
-        # Rz(2k + 0.5)Rx(b)Rz(2m + 0.5) = -i(-1)^{k+m}SX.Rz(1-b).SX
-        circ.SX(0).Rz(1 - b, 0).SX(0)
-        correction_phase += int_half(float(a) - 0.5) + int_half(float(c) - 0.5) - 0.5
-    else:
-        circ.Rz(c + 0.5, 0).SX(0).Rz(b - 1, 0).SX(0).Rz(a + 0.5, 0)
-        correction_phase += -0.5
-
-    circ.add_phase(correction_phase)
-    return circ
 
 
 class IBMQBackend(Backend):
@@ -430,11 +359,8 @@ class IBMQBackend(Backend):
         return (str, int, str)
 
     def rebase_pass(self) -> BasePass:
-        return RebaseCustom(
-            {OpType.CX},
-            Circuit(2).CX(0, 1),
-            {OpType.X, OpType.SX, OpType.Rz},
-            _tk1_to_x_sx_rz,
+        return auto_rebase_pass(
+            {OpType.CX, OpType.X, OpType.SX, OpType.Rz},
         )
 
     def process_circuits(

--- a/modules/pytket-qiskit/setup.py
+++ b/modules/pytket-qiskit/setup.py
@@ -38,7 +38,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.0.0rc0", "qiskit ~= 0.34.2"],
+    install_requires=["pytket == 1.0.0rc8", "qiskit ~= 0.34.2"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-qsharp/pytket/extensions/qsharp/backends/common.py
+++ b/modules/pytket-qsharp/pytket/extensions/qsharp/backends/common.py
@@ -45,6 +45,7 @@ from pytket.passes import (  # type: ignore
     FullPeepholeOptimise,
     FlattenRegisters,
 )
+from pytket._tket.circuit._library import _TK1_to_RzRx  # type: ignore
 from pytket.predicates import (  # type: ignore
     GateSetPredicate,
     NoClassicalControlPredicate,
@@ -59,14 +60,6 @@ from pytket.extensions.qsharp.qsharp_convert import tk_to_qsharp
 
 if TYPE_CHECKING:
     from qsharp.loader import QSharpCallable  # type: ignore
-
-
-def _from_tk1(a: float, b: float, c: float) -> Circuit:
-    circ = Circuit(1)
-    circ.Rz(c, 0)
-    circ.Rx(b, 0)
-    circ.Rz(a, 0)
-    return circ
 
 
 def qs_predicates(gate_set: Set[OpType]) -> List[Predicate]:
@@ -124,9 +117,6 @@ class _QsharpBaseBackend(Backend):
                 OpType.PauliExpBox,
                 OpType.SWAP,
                 OpType.CnX,
-            },  # multiqs
-            Circuit(),  # cx_replacement (irrelevant)
-            {
                 OpType.H,
                 OpType.Rx,
                 OpType.Ry,
@@ -136,8 +126,9 @@ class _QsharpBaseBackend(Backend):
                 OpType.X,
                 OpType.Y,
                 OpType.Z,
-            },  # singleqs
-            _from_tk1,
+            },
+            Circuit(),  # cx_replacement (irrelevant)
+            _TK1_to_RzRx,
         )  # tk1_replacement
 
     def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:

--- a/modules/pytket-qsharp/setup.py
+++ b/modules/pytket-qsharp/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket == 1.0.0rc0",
+        "pytket == 1.0.0rc8",
         "qsharp ~= 0.22.186910",
         "qsharp-core ~= 0.22.186910",
     ],

--- a/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
+++ b/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
@@ -39,7 +39,6 @@ from pytket.passes import (  # type: ignore
     SynthesiseTket,
     SequencePass,
     DecomposeBoxes,
-    RebaseCustom,
     FullPeepholeOptimise,
     FlattenRegisters,
 )
@@ -53,6 +52,7 @@ from pytket.predicates import (  # type: ignore
     Predicate,
 )
 from pytket.circuit import Pauli  # type: ignore
+from pytket.passes import auto_rebase_pass
 from pytket.pauli import QubitPauliString  # type: ignore
 from pytket.routing import Architecture  # type: ignore
 from pytket.utils.operators import QubitPauliOperator
@@ -137,12 +137,7 @@ class QulacsBackend(Backend):
         ]
 
     def rebase_pass(self) -> BasePass:
-        return RebaseCustom(
-            set(_TWO_QUBIT_GATES),
-            Circuit(2).CX(0, 1),
-            _1Q_GATES,
-            _tk1_to_u,
-        )
+        return auto_rebase_pass(set(_TWO_QUBIT_GATES) | _1Q_GATES)
 
     def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:
         assert optimisation_level in range(3)

--- a/modules/pytket-qulacs/setup.py
+++ b/modules/pytket-qulacs/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.0.0rc0", "Qulacs ~= 0.3.0"],
+    install_requires=["pytket == 1.0.0rc8", "Qulacs ~= 0.3.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-stim/pytket/extensions/stim/backends/stim_backend.py
+++ b/modules/pytket-stim/pytket/extensions/stim/backends/stim_backend.py
@@ -131,7 +131,7 @@ class StimBackend(Backend):
         ]
 
     def rebase_pass(self) -> BasePass:
-        return RebaseCustom({OpType.CX}, Circuit(), {OpType.H, OpType.S}, _tk1_to_cliff)
+        return RebaseCustom({OpType.CX, OpType.H, OpType.S}, Circuit(), _tk1_to_cliff)
 
     def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:
         # No optimization.

--- a/modules/pytket-stim/setup.py
+++ b/modules/pytket-stim/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.0.0rc0", "stim ~= 1.4"],
+    install_requires=["pytket == 1.0.0rc8", "stim ~= 1.4"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
* use auto_squash and auto_rebase
* provide full gateset as one argument to RebaseCustom
* remove use of Rebase<Target> passes

requires changes from
https://github.com/CQCL/tket/pull/234

and
https://github.com/CQCL/tket/pull/214