### PR TITLE
Remove default batch params if submitting to HQS family device.

### DIFF
--- a/modules/pytket-honeywell/pytket/extensions/honeywell/backends/honeywell.py
+++ b/modules/pytket-honeywell/pytket/extensions/honeywell/backends/honeywell.py
@@ -59,6 +59,7 @@ from .credential_storage import PersistentStorage
 
 _DEBUG_HANDLE_PREFIX = "_MACHINE_DEBUG_"
 HONEYWELL_URL_PREFIX = "https://qapi.honeywell.com/"
+DEVICE_FAMILY = "HQS-LT"
 
 _STATUS_MAP = {
     "queued": StatusEnum.QUEUED,
@@ -363,10 +364,13 @@ class HoneywellBackend(Backend):
 
             if final_index > 0:
                 # only set batch fields if more than one job submitted
-                body["batch-exec"] = batch_exec
-                if i == final_index:
-                    # flag to signal end of batch
-                    body["batch-end"] = True
+                if (self._device_name != DEVICE_FAMILY) or ("max_batch_cost" in kwargs):
+                    # Don't set default batch fields if submitting to the device family
+                    body["batch-exec"] = batch_exec
+                    if i == final_index:
+                        # flag to signal end of batch
+                        body["batch-end"] = True
+
             if circ.n_gates_of_type(OpType.ZZPhase) > 0:
                 body["options"]["compiler-options"] = {"parametrized_zz": True}
             if self._api_handler is None:

--- a/modules/pytket-honeywell/pytket/extensions/honeywell/backends/honeywell.py
+++ b/modules/pytket-honeywell/pytket/extensions/honeywell/backends/honeywell.py
@@ -362,14 +362,16 @@ class HoneywellBackend(Backend):
             body["program"] = honeywell_circ
             body["count"] = n_shots
 
-            if final_index > 0:
-                # only set batch fields if more than one job submitted
-                if (self._device_name != DEVICE_FAMILY) or ("max_batch_cost" in kwargs):
-                    # Don't set default batch fields if submitting to the device family
-                    body["batch-exec"] = batch_exec
-                    if i == final_index:
-                        # flag to signal end of batch
-                        body["batch-end"] = True
+            if final_index > 0 and (
+                self._device_name != DEVICE_FAMILY or "max_batch_cost" in kwargs
+            ):
+                # Don't set default batch fields if:
+                #  - Submitting to the device family
+                #  - Less than one job submitted
+                body["batch-exec"] = batch_exec
+                if i == final_index:
+                    # flag to signal end of batch
+                    body["batch-end"] = True
 
             if circ.n_gates_of_type(OpType.ZZPhase) > 0:
                 body["options"]["compiler-options"] = {"parametrized_zz": True}

--- a/modules/pytket-honeywell/tests/api_test.py
+++ b/modules/pytket-honeywell/tests/api_test.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple
+from typing import Tuple, Optional
+import pytest
 
 from requests_mock.mocker import Mocker
 
 from pytket.extensions.honeywell.backends.api_wrappers import HoneywellQAPI
+from pytket.extensions.honeywell.backends import HoneywellBackend
+from pytket.circuit import Circuit  # type: ignore
 
 
 def test_hqs_login(
@@ -63,3 +66,61 @@ def test_machine_status(
 
     # Delete authentication tokens to clean them from the keyring
     mock_hqs_api_handler.delete_authentication()
+
+
+@pytest.mark.parametrize(
+    "chosen_device,max_batch_cost",
+    [("HQS-LT", 300), ("HQS-LT", None), ("HQS-LT-S1", 300), ("HQS-LT-S1", None)],
+)
+def test_device_family(
+    requests_mock: Mocker,
+    mock_hqs_api_handler: HoneywellQAPI,
+    chosen_device: str,
+    max_batch_cost: Optional[int],
+) -> None:
+    """Test that batch params are NOT supplied by default
+    if we are submitting to a device family.
+    Doing so will get an error response from the HQS API."""
+
+    fake_job_id = "abc-123"
+
+    requests_mock.register_uri(
+        "POST",
+        "https://qapi.honeywell.com/v1/job",
+        json={"job": fake_job_id},
+        headers={"Content-Type": "application/json"},
+    )
+
+    requests_mock.register_uri(
+        "GET",
+        f"https://qapi.honeywell.com/v1/job/{fake_job_id}?websocket=true",
+        json={"job": fake_job_id},
+        headers={"Content-Type": "application/json"},
+    )
+
+    family_backend = HoneywellBackend(
+        device_name=chosen_device,
+        machine_debug=True,
+    )
+    family_backend._api_handler = mock_hqs_api_handler
+
+    circ = Circuit(2, name="batching_test").H(0).CX(0, 1).measure_all()
+    circ = family_backend.get_compiled_circuit(circ)
+
+    kwargs = {}
+    if max_batch_cost is not None:
+        kwargs["max_batch_cost"] = max_batch_cost
+    family_backend.process_circuits(
+        circuits=[circ, circ], n_shots=10, valid_check=False, **kwargs
+    )
+
+    submitted_json = {}
+    if requests_mock.last_request:
+        submitted_json = requests_mock.last_request.json()
+
+    if chosen_device == "HQS-LT" and max_batch_cost is None:
+        assert "batch-exec" not in submitted_json.keys()
+        assert "batch-end" not in submitted_json.keys()
+    else:
+        assert "batch-exec" in submitted_json.keys()
+        assert "batch-end" in submitted_json.keys()


### PR DESCRIPTION
HQS (and pytket-honeywell) now allow users to submit to a 'device family' ("HQS-LT") instead of specifying the exact device they want to run on.

We checked with the developers of the HQS API and it turns out that if jobs are submitted to a device family and batching is requested in the request JSON then an error will be returned (as the circuits may be run on different machines).

This PR removes the insertion of default batch params in the case that the user is submitting to a device family. If a user manually inserts batch params then they the API will still return an error, which I figured should be the correct behaviour.