### PR TITLE
Require pytket 1.0.0rc14

### DIFF
--- a/modules/pytket-aqt/setup.py
+++ b/modules/pytket-aqt/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.0.0rc12", "requests ~= 2.22", "types-requests"],
+    install_requires=["pytket == 1.0.0rc14", "requests ~= 2.22", "types-requests"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-braket/_metadata.py
+++ b/modules/pytket-braket/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.16.0"
+__extension_version__ = "0.17.0"
 __extension_name__ = "pytket-braket"

--- a/modules/pytket-braket/docs/changelog.rst
+++ b/modules/pytket-braket/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+0.17.0 (unreleased)
+-------------------
+
+* Add optional "region" argument for initializing BraketBackend.
+
 0.16.0 (February 2022)
 ----------------------
 

--- a/modules/pytket-braket/docs/changelog.rst
+++ b/modules/pytket-braket/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 -------------------
 
 * Add optional "region" argument for initializing BraketBackend.
+* Update requirements for amazon-braket-sdk and amazon-braket-schemas.
 
 0.16.0 (February 2022)
 ----------------------

--- a/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
+++ b/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
@@ -213,6 +213,7 @@ class BraketBackend(Backend):
         self,
         local: bool = False,
         device: Optional[str] = None,
+        region: str = "",
         s3_bucket: Optional[str] = None,
         s3_folder: Optional[str] = None,
         device_type: Optional[str] = None,
@@ -271,7 +272,9 @@ class BraketBackend(Backend):
             self._device_type = _DeviceType.LOCAL
         else:
             self._device = AwsDevice(
-                "arn:aws:braket:::"
+                "arn:aws:braket:"
+                + region
+                + "::"
                 + "/".join(
                     ["device", device_type, provider, device],
                 ),

--- a/modules/pytket-braket/setup.py
+++ b/modules/pytket-braket/setup.py
@@ -37,7 +37,11 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.0.0rc14", "amazon-braket-sdk ~= 1.0"],
+    install_requires=[
+        "pytket == 1.0.0rc14",
+        "amazon-braket-sdk~=1.16",
+        "amazon-braket-schemas~=1.7",
+    ],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-braket/setup.py
+++ b/modules/pytket-braket/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.0.0rc12", "amazon-braket-sdk ~= 1.0"],
+    install_requires=["pytket == 1.0.0rc14", "amazon-braket-sdk ~= 1.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-braket/tests/backend_test.py
+++ b/modules/pytket-braket/tests/backend_test.py
@@ -124,7 +124,7 @@ def test_rigetti() -> None:
     b = BraketBackend(
         device_type="qpu",
         provider="rigetti",
-        device="Aspen-11",
+        device="Aspen-M-1",
     )
     assert b.persistent_handles
     assert b.supports_shots
@@ -161,7 +161,7 @@ def test_rigetti_with_rerouting() -> None:
     b = BraketBackend(
         device_type="qpu",
         provider="rigetti",
-        device="Aspen-11",
+        device="Aspen-M-1",
     )
     c = Circuit(4).CX(0, 1).CX(0, 2).CX(0, 3).CX(1, 2).CX(1, 3).CX(2, 3)
     c = b.get_compiled_circuit(c)

--- a/modules/pytket-braket/tests/backend_test.py
+++ b/modules/pytket-braket/tests/backend_test.py
@@ -122,9 +122,7 @@ def test_ionq() -> None:
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_rigetti() -> None:
     b = BraketBackend(
-        device_type="qpu",
-        provider="rigetti",
-        device="Aspen-M-1",
+        device_type="qpu", provider="rigetti", device="Aspen-M-1", region="us-west-1"
     )
     assert b.persistent_handles
     assert b.supports_shots
@@ -159,9 +157,7 @@ def test_rigetti() -> None:
 def test_rigetti_with_rerouting() -> None:
     # A circuit that requires rerouting to a non-fully-connected architecture
     b = BraketBackend(
-        device_type="qpu",
-        provider="rigetti",
-        device="Aspen-M-1",
+        device_type="qpu", provider="rigetti", device="Aspen-M-1", region="us-west-1"
     )
     c = Circuit(4).CX(0, 1).CX(0, 2).CX(0, 3).CX(1, 2).CX(1, 3).CX(2, 3)
     c = b.get_compiled_circuit(c)

--- a/modules/pytket-cirq/setup.py
+++ b/modules/pytket-cirq/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket == 1.0.0rc12",
+        "pytket == 1.0.0rc14",
         "cirq-core ~= 0.13.0",
         "cirq-google ~= 0.13.0",
     ],

--- a/modules/pytket-honeywell/setup.py
+++ b/modules/pytket-honeywell/setup.py
@@ -38,7 +38,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket == 1.0.0rc12",
+        "pytket == 1.0.0rc14",
         "requests >= 2.2",
         "types-requests",
         "websockets >= 7.0",

--- a/modules/pytket-ionq/setup.py
+++ b/modules/pytket-ionq/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.0.0rc12", "requests ~= 2.22", "types-requests"],
+    install_requires=["pytket == 1.0.0rc14", "requests ~= 2.22", "types-requests"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-iqm/setup.py
+++ b/modules/pytket-iqm/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.0.0rc12", "iqm-client ~= 1.6"],
+    install_requires=["pytket == 1.0.0rc14", "iqm-client ~= 1.6"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.9",

--- a/modules/pytket-projectq/setup.py
+++ b/modules/pytket-projectq/setup.py
@@ -38,7 +38,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.0.0rc12", "projectq ~= 0.7.0"],
+    install_requires=["pytket == 1.0.0rc14", "projectq ~= 0.7.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-pyquil/setup.py
+++ b/modules/pytket-pyquil/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket == 1.0.0rc12",
+        "pytket == 1.0.0rc14",
         "pyquil ~= 3.0",
         "typing-extensions ~= 3.7",
     ],

--- a/modules/pytket-pyzx/setup.py
+++ b/modules/pytket-pyzx/setup.py
@@ -38,7 +38,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.0.0rc12", "pyzx ~= 0.7.0"],
+    install_requires=["pytket == 1.0.0rc14", "pyzx ~= 0.7.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-qiskit/setup.py
+++ b/modules/pytket-qiskit/setup.py
@@ -38,7 +38,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.0.0rc12", "qiskit ~= 0.34.2"],
+    install_requires=["pytket == 1.0.0rc14", "qiskit ~= 0.34.2"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-qiskit/tests/backend_test.py
+++ b/modules/pytket-qiskit/tests/backend_test.py
@@ -26,7 +26,7 @@ from pytket.passes import CliffordSimp  # type: ignore
 from pytket.pauli import Pauli, QubitPauliString  # type: ignore
 from pytket.predicates import CompilationUnit, NoMidMeasurePredicate  # type: ignore
 from pytket.architecture import Architecture  # type: ignore
-from pytket.mapping import MappingManager, LexiRouteRoutingMethod  # type: ignore
+from pytket.mapping import MappingManager, LexiLabellingMethod, LexiRouteRoutingMethod  # type: ignore
 from pytket.transform import Transform  # type: ignore
 from pytket.backends import (
     ResultHandle,
@@ -530,7 +530,7 @@ def test_routing_measurements() -> None:
     coupling = [[1, 0], [2, 0], [2, 1], [3, 2], [3, 4], [4, 2]]
     arc = Architecture(coupling)
     mm = MappingManager(arc)
-    mm.route_circuit(physical_c, [LexiRouteRoutingMethod()])
+    mm.route_circuit(physical_c, [LexiLabellingMethod(), LexiRouteRoutingMethod()])
     Transform.DecomposeSWAPtoCX().apply(physical_c)
     Transform.DecomposeCXDirected(arc).apply(physical_c)
     Transform.OptimisePostRouting().apply(physical_c)

--- a/modules/pytket-qsharp/setup.py
+++ b/modules/pytket-qsharp/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket == 1.0.0rc12",
+        "pytket == 1.0.0rc14",
         "qsharp ~= 0.22.186910",
         "qsharp-core ~= 0.22.186910",
     ],

--- a/modules/pytket-qulacs/setup.py
+++ b/modules/pytket-qulacs/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.0.0rc12", "Qulacs ~= 0.3.0"],
+    install_requires=["pytket == 1.0.0rc14", "Qulacs ~= 0.3.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",

--- a/modules/pytket-stim/setup.py
+++ b/modules/pytket-stim/setup.py
@@ -37,7 +37,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.0.0rc12", "stim ~= 1.4"],
+    install_requires=["pytket == 1.0.0rc14", "stim ~= 1.4"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Fix up a pytket-qiskit test.

Also add "region" argument to `BraketBackend` constructor and fix up tests following retirement of Aspen-11.

(I tried adding a test for the new OQC device, but it didn't like the ARN; this will need to be investigated separately.)