### PR TITLE
[TKET-1749] Fix circuit parameter conversion bug when complex.

### DIFF
--- a/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
@@ -215,9 +215,12 @@ def _tk_gate_set(backend: "QiskitBackend") -> Set[OpType]:
 
 
 def _qpo_from_peg(peg: PauliEvolutionGate, qubits: List[Qubit]) -> QubitPauliOperator:
+    import numpy as np
     op = peg.operator
     qpodict = {}
     for p, c in zip(op.paulis, op.coeffs):
+        if np.iscomplex(c):
+            raise ValueError("Coefficient for Pauli {} is non-real.".format(p))
         qpslist = []
         pstr = p.to_label()
         for a in pstr:

--- a/modules/pytket-qiskit/tests/qiskit_convert_test.py
+++ b/modules/pytket-qiskit/tests/qiskit_convert_test.py
@@ -57,6 +57,15 @@ skip_remote_tests: bool = (
 )
 
 
+def test_convert_circuit_with_complex_params() -> None:
+    with pytest.raises(ValueError):
+        qiskit_op = PauliSumOp.from_list([("Z", 1j)])
+        evolved_op = qiskit_op.exp_i()
+        evolution_circ = PauliTrotterEvolution(reps=1).convert(evolved_op).to_circuit()
+        tk_circ = qiskit_to_tk(evolution_circ)
+        DecomposeBoxes().apply(tk_circ)
+
+
 def get_test_circuit(measure: bool, reset: bool = True) -> QuantumCircuit:
     qr = QuantumRegister(4)
     cr = ClassicalRegister(4)


### PR DESCRIPTION
Fixes [TKET-1749](https://cqc.atlassian.net/browse/TKET-1749?atlOrigin=eyJpIjoiM2MzN2Q2YTRlM2EzNDJlZGI3ODE3MWJjNjYxNzJjMDAiLCJwIjoiaiJ9)

This PR fixes the bug reported in #258 and adds exception being thrown when a coefficient in a Pauli string is non-real.