### PR TITLE
[pytket-quantinuum] simplify quantinuum auth and remove unused API methods

### DIFF
--- a/modules/pytket-quantinuum/docs/changelog.rst
+++ b/modules/pytket-quantinuum/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 
 * Module renamed from "pytket.extensions.honeywell" to
   "pytket.extensions.quantinumm", with corresponding name changes throughout.
+* Simplify authentication: use ``QuantinuumBackend.login()`` to log in once per session.
 
 Old changelog for "pytket-honeywell":
 

--- a/modules/pytket-quantinuum/docs/intro.txt
+++ b/modules/pytket-quantinuum/docs/intro.txt
@@ -15,7 +15,7 @@ and Windows. To install, run:
 
 
 .. note::   Requires a `Quantinuum <https://www.quantinuum.com/>`_ account.
-            When initialising the backend for the first time, you will be prompted for your username and password.
+            Use ``QuantinuumBackend.login()`` to log in using your email and password.
 
 .. toctree::
     api.rst

--- a/modules/pytket-quantinuum/pytket/extensions/quantinuum/__init__.py
+++ b/modules/pytket-quantinuum/pytket/extensions/quantinuum/__init__.py
@@ -18,4 +18,3 @@
 # _metadata.py is copied to the folder after installation.
 from ._metadata import __extension_version__, __extension_name__  # type: ignore
 from .backends import QuantinuumBackend
-from .backends.credential_storage import split_utf8

--- a/modules/pytket-quantinuum/pytket/extensions/quantinuum/backends/__init__.py
+++ b/modules/pytket-quantinuum/pytket/extensions/quantinuum/backends/__init__.py
@@ -16,4 +16,3 @@
 """
 
 from .quantinuum import QuantinuumBackend
-from .credential_storage import split_utf8

--- a/modules/pytket-quantinuum/pytket/extensions/quantinuum/backends/credential_storage.py
+++ b/modules/pytket-quantinuum/pytket/extensions/quantinuum/backends/credential_storage.py
@@ -12,182 +12,78 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable, Optional
-from abc import ABC, abstractmethod
-from itertools import takewhile, count
-import keyring
+from typing import Optional
+from datetime import timedelta, datetime, timezone
+
+import jwt
 
 
-def split_utf8(s: str, n: int) -> Iterable[str]:
-    # stolen from
-    # https://stackoverflow.com/questions/6043463/split-unicode-string-into-300-byte-chunks-without-destroying-characters
-    """Split UTF-8 s into chunks of maximum length n."""
-    s_bytes = s.encode("utf-8")
-    while len(s_bytes) > n:
-        k = n
-        while (s_bytes[k] & 0xC0) == 0x80:
-            k -= 1
-        yield s_bytes[:k].decode("utf-8")
-        s_bytes = s_bytes[k:]
-    yield s_bytes.decode("utf-8")
+class MemoryCredentialStorage:
 
+    """In memory credential storage. Intended use is only to store id tokens and
+    refresh tokens, username/password storage is only included for debug purposes."""
 
-class CredentialStorage(ABC):
-    """Abstract class for managing credentials and tokens for the Quantinuum API."""
-
-    @abstractmethod
-    def save_login_credential(self, user_name: str, password: str) -> None:
-        """Save the user_name and password"""
-        ...
-
-    @abstractmethod
-    def login_credential(self, user_name: str) -> Optional[str]:
-        """Retrieve the password associated with the user_name"""
-        ...
-
-    @abstractmethod
-    def save_tokens(self, id_token: str, refresh_token: str) -> None:
-        """Save the id_token and refresh_token"""
-        ...
-
-    @abstractmethod
-    def save_refresh_token(self, refresh_token: str) -> None:
-        """Save the refresh_token"""
-        ...
-
-    @property
-    @abstractmethod
-    def id_token(self) -> Optional[str]:
-        """Retrieve the id_token"""
-        ...
-
-    @property
-    @abstractmethod
-    def refresh_token(self) -> Optional[str]:
-        """Retrieve the refresh_token"""
-        ...
-
-    @abstractmethod
-    def delete_login_credential(self, user_name: str) -> None:
-        """Delete the stored username and password"""
-        ...
-
-    @abstractmethod
-    def delete_tokens(self) -> None:
-        """Delete the refresh_token and id_token"""
-        ...
-
-
-class MemoryStorage(CredentialStorage):
-
-    """In memory credential storage"""
-
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        id_token_timedelt: timedelta = timedelta(minutes=55),
+        refresh_token_timedelt: timedelta = timedelta(days=29),
+    ) -> None:
         self._user_name: Optional[str] = None
         self._password: Optional[str] = None
+
+        self._id_timedelt = id_token_timedelt
+        self._refresh_timedelt = refresh_token_timedelt
+
         self._id_token: Optional[str] = None
         self._refresh_token: Optional[str] = None
+        self._id_token_timeout: Optional[datetime] = None
+        self._refresh_token_timeout: Optional[datetime] = None
 
-    def save_login_credential(self, user_name: str, password: str) -> None:
+    def _save_login_credential(self, user_name: str, password: str) -> None:
         self._user_name = user_name
         self._password = password
 
-    def login_credential(self, user_name: str) -> Optional[str]:
-        self._user_name = user_name
-        return None if self._password is None else self._password
-
     def save_tokens(self, id_token: str, refresh_token: str) -> None:
-        self._id_token = id_token
-        self._refresh_token = refresh_token
+        self.save_id_token(id_token)
+        self.save_refresh_token(refresh_token)
 
     def save_refresh_token(self, refresh_token: str) -> None:
         self._refresh_token = refresh_token
+        self._refresh_token_timeout = (
+            datetime.now(timezone.utc) + self._refresh_timedelt
+        )
+
+    def save_id_token(self, id_token: str) -> None:
+        self._id_token = id_token
+        self._id_token_timeout = datetime.now(timezone.utc) + self._id_timedelt
 
     @property
     def id_token(self) -> Optional[str]:
+        if self._id_token is not None:
+            timeout = jwt.decode(self._id_token, verify=False)["exp"] - 60
+            if self._id_token_timeout is not None:
+                timeout = min(timeout, self._id_token_timeout.timestamp())
+            if datetime.now(timezone.utc).timestamp() > timeout:
+                self._id_token = None
         return self._id_token
 
     @property
     def refresh_token(self) -> Optional[str]:
+        if self._refresh_token is not None and self._refresh_token_timeout is not None:
+            if datetime.now(timezone.utc) > self._refresh_token_timeout:
+                self._refresh_token = None
         return self._refresh_token
 
-    def delete_login_credential(self, user_name: str) -> None:
+    def _delete_login_credential(self) -> None:
+        del self._user_name
+        del self._password
         self._user_name = None
         self._password = None
 
     def delete_tokens(self) -> None:
+        del self._id_token
+        del self._refresh_token
         self._id_token = None
+        self._id_token_timeout = None
         self._refresh_token = None
-
-
-class PersistentStorage(CredentialStorage):
-
-    """Persistent credential storage using keyring"""
-
-    KEYRING_SERVICE = "HQS-API"
-
-    def save_login_credential(self, user_name: str, password: str) -> None:
-        keyring.set_password(self.KEYRING_SERVICE, user_name, password)
-
-    def login_credential(self, user_name: str) -> Optional[str]:
-        password = keyring.get_password(self.KEYRING_SERVICE, user_name)
-        return None if password is None else password
-
-    def save_tokens(self, id_token: str, refresh_token: str) -> None:
-        """Method to save id and refresh tokens on system's keyring service.
-        Windows keyring backend has a length limitation on passwords.
-        To avoid this, passwords get split in to tokens of length 512.
-        """
-
-        split_id_tokens = list(split_utf8(id_token, 512))
-        split_refresh_tokens = list(split_utf8(refresh_token, 512))
-
-        for token_list, token_name in zip(
-            (split_id_tokens, split_refresh_tokens), ("id_token", "refresh_token")
-        ):
-            for index, part in enumerate(token_list):
-                keyring.set_password(  # type: ignore
-                    self.KEYRING_SERVICE, f"{token_name}_{index}", part
-                )
-
-    def save_refresh_token(self, refresh_token: str) -> None:
-        split_refresh_tokens = list(split_utf8(refresh_token, 512))
-
-        for index, token_part in enumerate(split_refresh_tokens):
-            keyring.set_password(  # type: ignore
-                self.KEYRING_SERVICE, f"refresh_token_{index}", token_part
-            )
-
-    @property
-    def id_token(self) -> Optional[str]:
-        token = "".join(self._get_token_parts("id_token"))
-        return token if token else None
-
-    @property
-    def refresh_token(self) -> Optional[str]:
-        token = "".join(self._get_token_parts("refresh_token"))
-        return token if token else None
-
-    def delete_login_credential(self, user_name: str) -> None:
-        try:
-            keyring.delete_password(self.KEYRING_SERVICE, user_name)
-        except keyring.errors.PasswordDeleteError:
-            pass
-
-    def delete_tokens(self) -> None:
-        """Delete tokens in the keyring"""
-        for token_name in ("id_token", "refresh_token"):
-            for index in count():
-                token_part = f"{token_name}_{index}"
-                try:
-                    keyring.delete_password(self.KEYRING_SERVICE, token_part)
-                except keyring.errors.PasswordDeleteError:
-                    # stop when the token part doesn't exist
-                    break
-
-    def _get_token_parts(self, token_name: str) -> Iterable[str]:
-        token_parts = (
-            keyring.get_password(self.KEYRING_SERVICE, f"{token_name}_{i}")  # type: ignore
-            for i in count(start=0)
-        )
-        return takewhile(lambda x: x is not None, token_parts)  # type: ignore
+        self._refresh_token_timeout = None

--- a/modules/pytket-quantinuum/setup.py
+++ b/modules/pytket-quantinuum/setup.py
@@ -45,7 +45,6 @@ setup(
         "nest_asyncio >= 1.2",
         "pyjwt >= 1.7, < 2.0",
         "types-jwt",
-        "keyring >= 19.0",
     ],
     classifiers=[
         "Environment :: Console",

--- a/modules/pytket-quantinuum/tests/api1_test.py
+++ b/modules/pytket-quantinuum/tests/api1_test.py
@@ -32,7 +32,7 @@ from pytket.circuit import Circuit  # type: ignore
 )
 def test_device_family(
     requests_mock: Mocker,
-    mock_hqs_api_handler: QuantinuumQAPI,
+    mock_quum_api_handler: QuantinuumQAPI,
     chosen_device: str,
     max_batch_cost: Optional[int],
 ) -> None:
@@ -60,7 +60,7 @@ def test_device_family(
         device_name=chosen_device,
         machine_debug=True,
     )
-    family_backend._api_handler = mock_hqs_api_handler
+    family_backend._api_handler = mock_quum_api_handler
 
     circ = Circuit(2, name="batching_test").H(0).CX(0, 1).measure_all()
     circ = family_backend.get_compiled_circuit(circ)

--- a/modules/pytket-quantinuum/tests/api1_test.py
+++ b/modules/pytket-quantinuum/tests/api1_test.py
@@ -58,7 +58,6 @@ def test_device_family(
 
     family_backend = QuantinuumBackend(
         device_name=chosen_device,
-        machine_debug=True,
     )
     family_backend._api_handler = mock_quum_api_handler
 

--- a/modules/pytket-quantinuum/tests/api_test.py
+++ b/modules/pytket-quantinuum/tests/api_test.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple
+from io import StringIO
+from typing import Any, Tuple
 
 from requests_mock.mocker import Mocker
 
@@ -27,17 +28,17 @@ def test_quum_login(
     """Test that credentials are storable and deletable using
     the QuantinuumQAPI handler."""
 
-    username, pwd = mock_credentials
+    _, pwd = mock_credentials
 
     # Check credentials are retrievable
-    assert mock_quum_api_handler._cred_store.login_credential(username) == pwd
+    assert mock_quum_api_handler._cred_store._password == pwd
     assert mock_quum_api_handler._cred_store.refresh_token == mock_token
     assert mock_quum_api_handler._cred_store.id_token == mock_token
 
     # Delete authentication and verify
     mock_quum_api_handler.delete_authentication()
     assert mock_quum_api_handler._cred_store.id_token == None
-    assert mock_quum_api_handler._cred_store.login_credential(username) == None
+    assert mock_quum_api_handler._cred_store._password == None
     assert mock_quum_api_handler._cred_store.refresh_token == None
 
 
@@ -47,7 +48,7 @@ def test_machine_status(
 ) -> None:
     """Test that we can retrieve the machine state via  Quantinuum endpoint."""
 
-    machine_name = "HQS-LT-S1-APIVAL"
+    machine_name = "quum-LT-S1-APIVAL"
     mock_machine_state = "online"
 
     mock_url = f"https://qapi.quantinuum.com/v1/machine/{machine_name}"
@@ -61,5 +62,55 @@ def test_machine_status(
 
     assert mock_quum_api_handler.status(machine_name) == mock_machine_state
 
-    # Delete authentication tokens to clean them from the keyring
+    # Delete authentication tokens to clean them from memory
     mock_quum_api_handler.delete_authentication()
+
+
+def test_full_login(
+    requests_mock: Mocker,
+    mock_credentials: Tuple[str, str],
+    mock_token: str,
+    monkeypatch: Any,
+) -> None:
+    username, pwd = mock_credentials
+
+    mock_url = "https://qapi.quantinuum.com/v1/login"
+
+    requests_mock.register_uri(
+        "POST",
+        mock_url,
+        json={
+            "id-token": mock_token,
+            "refresh-token": "refresh" + mock_token,
+        },
+        headers={"Content-Type": "application/json"},
+    )
+
+    # fake user input from stdin
+    monkeypatch.setattr("sys.stdin", StringIO(username + "\n"))
+    monkeypatch.setattr("getpass.getpass", lambda prompt: pwd)
+
+    api_handler = QuantinuumQAPI()
+    # emulate no pytket config stored email address
+    api_handler.config.username = None
+    api_handler.full_login()
+
+    assert api_handler._cred_store.id_token == mock_token
+    assert api_handler._cred_store.refresh_token == "refresh" + mock_token
+    assert api_handler._cred_store._id_token_timeout is not None
+    assert api_handler._cred_store._refresh_token_timeout is not None
+
+    assert api_handler._cred_store._password is None
+    assert api_handler._cred_store._user_name is None
+
+    api_handler.delete_authentication()
+
+    assert all(
+        val is None
+        for val in (
+            api_handler._cred_store.id_token,
+            api_handler._cred_store.refresh_token,
+            api_handler._cred_store._id_token_timeout,
+            api_handler._cred_store._refresh_token_timeout,
+        )
+    )

--- a/modules/pytket-quantinuum/tests/api_test.py
+++ b/modules/pytket-quantinuum/tests/api_test.py
@@ -19,8 +19,8 @@ from requests_mock.mocker import Mocker
 from pytket.extensions.quantinuum.backends.api_wrappers import QuantinuumQAPI
 
 
-def test_hqs_login(
-    mock_hqs_api_handler: QuantinuumQAPI,
+def test_quum_login(
+    mock_quum_api_handler: QuantinuumQAPI,
     mock_credentials: Tuple[str, str],
     mock_token: str,
 ) -> None:
@@ -30,20 +30,20 @@ def test_hqs_login(
     username, pwd = mock_credentials
 
     # Check credentials are retrievable
-    assert mock_hqs_api_handler._cred_store.login_credential(username) == pwd
-    assert mock_hqs_api_handler._cred_store.refresh_token == mock_token
-    assert mock_hqs_api_handler._cred_store.id_token == mock_token
+    assert mock_quum_api_handler._cred_store.login_credential(username) == pwd
+    assert mock_quum_api_handler._cred_store.refresh_token == mock_token
+    assert mock_quum_api_handler._cred_store.id_token == mock_token
 
     # Delete authentication and verify
-    mock_hqs_api_handler.delete_authentication()
-    assert mock_hqs_api_handler._cred_store.id_token == None
-    assert mock_hqs_api_handler._cred_store.login_credential(username) == None
-    assert mock_hqs_api_handler._cred_store.refresh_token == None
+    mock_quum_api_handler.delete_authentication()
+    assert mock_quum_api_handler._cred_store.id_token == None
+    assert mock_quum_api_handler._cred_store.login_credential(username) == None
+    assert mock_quum_api_handler._cred_store.refresh_token == None
 
 
 def test_machine_status(
     requests_mock: Mocker,
-    mock_hqs_api_handler: QuantinuumQAPI,
+    mock_quum_api_handler: QuantinuumQAPI,
 ) -> None:
     """Test that we can retrieve the machine state via  Quantinuum endpoint."""
 
@@ -59,7 +59,7 @@ def test_machine_status(
         headers={"Content-Type": "application/json"},
     )
 
-    assert mock_hqs_api_handler.status(machine_name) == mock_machine_state
+    assert mock_quum_api_handler.status(machine_name) == mock_machine_state
 
     # Delete authentication tokens to clean them from the keyring
-    mock_hqs_api_handler.delete_authentication()
+    mock_quum_api_handler.delete_authentication()

--- a/modules/pytket-quantinuum/tests/backend_test.py
+++ b/modules/pytket-quantinuum/tests/backend_test.py
@@ -41,7 +41,6 @@ from pytket.extensions.quantinuum.backends.quantinuum import (
     GetResultFailed,
     _GATE_SET,
 )
-from pytket.extensions.quantinuum import split_utf8
 from pytket.extensions.quantinuum.backends.api_wrappers import (
     HQSAPIError,
     QuantinuumQAPI,
@@ -49,6 +48,7 @@ from pytket.extensions.quantinuum.backends.api_wrappers import (
 from pytket.backends.status import StatusEnum
 
 skip_remote_tests: bool = os.getenv("PYTKET_RUN_REMOTE_TESTS") is None
+
 REASON = (
     "PYTKET_RUN_REMOTE_TESTS not set (requires configuration of Quantinuum username)"
 )
@@ -288,16 +288,6 @@ def test_shots_bits_edgecases(n_shots, n_bits) -> None:
     assert np.array_equal(res.get_shots(), correct_shots)
     assert res.get_shots().shape == correct_shape
     assert res.get_counts() == correct_counts
-
-
-@given(
-    utf_str=st.text(min_size=0, max_size=3000),
-    chunksize=st.integers(min_value=4, max_value=1030),
-)
-def test_split_utf8(utf_str: str, chunksize: int) -> None:
-    split = list(split_utf8(utf_str, chunksize))
-    assert max(len(i) for i in split) <= chunksize
-    assert "".join(split) == utf_str
 
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)

--- a/modules/pytket-quantinuum/tests/conftest.py
+++ b/modules/pytket-quantinuum/tests/conftest.py
@@ -43,8 +43,8 @@ def mock_token() -> str:
     return mock_token
 
 
-@pytest.fixture(name="mock_hqs_api_handler", params=[True, False])
-def fixture_mock_hqs_api_handler(
+@pytest.fixture(name="mock_quum_api_handler", params=[True, False])
+def fixture_mock_quum_api_handler(
     request: SubRequest,
     requests_mock: Mocker,
     mock_credentials: Tuple[str, str],
@@ -52,7 +52,7 @@ def fixture_mock_hqs_api_handler(
 ) -> QuantinuumQAPI:
     """A logged-in QuantinuumQAPI fixture.
     After using this fixture in a test, call:
-        mock_hqs_api_handler.delete_authentication()
+        mock_quum_api_handler.delete_authentication()
     To remove mock tokens from the keyring.
     """
 

--- a/modules/pytket-quantinuum/tests/convert_test.py
+++ b/modules/pytket-quantinuum/tests/convert_test.py
@@ -25,7 +25,7 @@ def test_convert() -> None:
     circ.add_barrier([2])
     circ.measure_all()
 
-    QuantinuumBackend("", login=False, machine_debug=True).rebase_pass().apply(circ)
+    QuantinuumBackend("", machine_debug=True).rebase_pass().apply(circ)
     circ_quum = circuit_to_qasm_str(circ, header="hqslib1")
     qasm_str = circ_quum.split("\n")[6:-1]
     assert all(
@@ -42,7 +42,7 @@ def test_convert_rzz() -> None:
     circ.add_gate(OpType.ZZMax, [2, 3])
     circ.measure_all()
 
-    QuantinuumBackend("", login=False, machine_debug=True).rebase_pass().apply(circ)
+    QuantinuumBackend("", machine_debug=True).rebase_pass().apply(circ)
     circ_quum = circuit_to_qasm_str(circ, header="hqslib1")
     qasm_str = circ_quum.split("\n")[6:-1]
     assert all(

--- a/modules/pytket-quantinuum/tests/convert_test.py
+++ b/modules/pytket-quantinuum/tests/convert_test.py
@@ -26,8 +26,8 @@ def test_convert() -> None:
     circ.measure_all()
 
     QuantinuumBackend("", login=False, machine_debug=True).rebase_pass().apply(circ)
-    circ_hqs = circuit_to_qasm_str(circ, header="hqslib1")
-    qasm_str = circ_hqs.split("\n")[6:-1]
+    circ_quum = circuit_to_qasm_str(circ, header="hqslib1")
+    qasm_str = circ_quum.split("\n")[6:-1]
     assert all(
         any(com.startswith(gate) for gate in ("rz", "U1q", "ZZ", "measure", "barrier"))
         for com in qasm_str
@@ -43,8 +43,8 @@ def test_convert_rzz() -> None:
     circ.measure_all()
 
     QuantinuumBackend("", login=False, machine_debug=True).rebase_pass().apply(circ)
-    circ_hqs = circuit_to_qasm_str(circ, header="hqslib1")
-    qasm_str = circ_hqs.split("\n")[6:-1]
+    circ_quum = circuit_to_qasm_str(circ, header="hqslib1")
+    qasm_str = circ_quum.split("\n")[6:-1]
     assert all(
         any(com.startswith(gate) for gate in ("rz", "U1q", "ZZ", "measure", "RZZ"))
         for com in qasm_str


### PR DESCRIPTION

This is motivated by a couple of major factors:
* Storing passwords unencrypted is bad
* `keyring` is a difficult package to use cross platform as it requires
platform specific backends
* JWT id tokens expire quickly

Previously we would store id and refresh tokens using keyring. In theory
if an in date refresh token exists that is used to retrive a new ID
token. A frequent user would only have to log in once.

When this proved unstable we added the ability to also store your
password in keyring, and just recommended against it.
When this also proved unstable we added hack upon hack and recommended
frequent clearing of credentials and retries.

This PR aims to simplify this by requiring a log in for each session.
Username/email can be stored in pytket config and so will not be
requested each time. Password once per session, and never stored
(after making the login API request). Refresh and ID tokens are only
stored in memory, and the refresh token is used for long running
sessions to update the ID token. Internal time stamps are used to
make (hopefully) minimal login requests.

The keyring dependency is totally removed.
NOTE: running remote tests will always require a login from STDIN