### PR TITLE
Build with 3.9, not 3.10, in release workflow.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -65,19 +65,21 @@ jobs:
       run: |
         ./.github/workflows/build-test nomypy
     - name: Set up Python 3.9
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' || github.event_name == 'release' || contains(github.ref, 'refs/heads/wheel')
       uses: actions/setup-python@v2
       with:
         python-version: '3.9'
     - name: Build and test (3.9)
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' || github.event_name == 'release' || contains(github.ref, 'refs/heads/wheel')
       run: |
         ./.github/workflows/build-test nomypy
     - name: Set up Python 3.10
+      if: github.event_name == 'push' || github.event_name == 'pull_request'
       uses: actions/setup-python@v2
       with:
         python-version: '3.10'
     - name: Build and test (3.10)
+      if: github.event_name == 'push' || github.event_name == 'pull_request'
       run: |
         ./.github/workflows/build-test nomypy
     - uses: actions/upload-artifact@v2


### PR DESCRIPTION
Because 3.9 is the only version where all extensions are supported.