### PR TITLE
fix braket task failure status reason

### DIFF
--- a/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
+++ b/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
@@ -677,8 +677,7 @@ class BraketBackend(Backend):
         task = AwsQuantumTask(task_id, aws_session=self._aws_session)
         state = task.state()
         if state == "FAILED":
-            result = task.result()
-            return CircuitStatus(StatusEnum.ERROR, result.task_metadata.failureReason)
+            return CircuitStatus(StatusEnum.ERROR, task.metadata()["failureReason"])
         elif state == "CANCELLED":
             return CircuitStatus(StatusEnum.CANCELLED)
         elif state == "COMPLETED":


### PR DESCRIPTION
Result object is None if the task fails.

If fail would like it to return the failureReason from Braket

https://github.com/aws/amazon-braket-sdk-python/blob/v1.16.0/src/braket/aws/aws_quantum_task.py#L286-L288

Also is the same in latest versions as well