### PR TITLE
[pytket-ionq] Ionq simulator qubits is 29 not 11

### DIFF
--- a/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
+++ b/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
@@ -677,8 +677,7 @@ class BraketBackend(Backend):
         task = AwsQuantumTask(task_id, aws_session=self._aws_session)
         state = task.state()
         if state == "FAILED":
-            result = task.result()
-            return CircuitStatus(StatusEnum.ERROR, result.task_metadata.failureReason)
+            return CircuitStatus(StatusEnum.ERROR, task.metadata()["failureReason"])
         elif state == "CANCELLED":
             return CircuitStatus(StatusEnum.CANCELLED)
         elif state == "COMPLETED":

--- a/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq.py
+++ b/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq.py
@@ -53,8 +53,6 @@ from .config import IonQConfig
 
 IONQ_JOBS_URL = "https://api.ionq.co/v0.1/jobs/"
 
-IONQ_N_QUBITS = 11
-
 _STATUS_MAP = {
     "completed": StatusEnum.COMPLETED,
     "failed": StatusEnum.ERROR,
@@ -112,7 +110,11 @@ class IonQBackend(Backend):
             api_key = config.api_key
         if api_key is None:
             raise IonQAuthenticationError()
-
+        if device_name == "qpu":
+            IONQ_N_QUBITS = 11
+        else:
+            IONQ_N_QUBITS = 29
+        
         self._header = {"Authorization": f"apiKey {api_key}"}
         self._backend_info = fully_connected_backendinfo(
             type(self).__name__,

--- a/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq.py
+++ b/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq.py
@@ -114,7 +114,7 @@ class IonQBackend(Backend):
             raise IonQAuthenticationError()
         if device_name is "simulator":
             IONQ_N_QUBITS = 29
-        
+
         self._header = {"Authorization": f"apiKey {api_key}"}
         self._backend_info = fully_connected_backendinfo(
             type(self).__name__,

--- a/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq.py
+++ b/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq.py
@@ -112,7 +112,7 @@ class IonQBackend(Backend):
             api_key = config.api_key
         if api_key is None:
             raise IonQAuthenticationError()
-        if device_name is "simulator":
+        if device_name == "simulator":
             IONQ_N_QUBITS = 29
 
         self._header = {"Authorization": f"apiKey {api_key}"}

--- a/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq.py
+++ b/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq.py
@@ -53,6 +53,8 @@ from .config import IonQConfig
 
 IONQ_JOBS_URL = "https://api.ionq.co/v0.1/jobs/"
 
+IONQ_N_QUBITS = 11
+
 _STATUS_MAP = {
     "completed": StatusEnum.COMPLETED,
     "failed": StatusEnum.ERROR,
@@ -110,9 +112,7 @@ class IonQBackend(Backend):
             api_key = config.api_key
         if api_key is None:
             raise IonQAuthenticationError()
-        if device_name == "qpu":
-            IONQ_N_QUBITS = 11
-        else:
+        if device_name is "simulator":
             IONQ_N_QUBITS = 29
         
         self._header = {"Authorization": f"apiKey {api_key}"}


### PR DESCRIPTION
Hello,

I would like to suggest the following change to the backend info for the IonQ device to bring the simulator n_nodes into line with the known number of 29 qubits from the current 11. 

"Many simulators are available in the quantum ecosystem, from run-it-yourself simulators packaged with open-source tools like [Qiskit](https://qiskit.org/documentation/tutorials/simulators/1_aer_provider.html) and [Cirq](https://quantumai.google/cirq/simulation), to standalone, hardware-optimized packages like [Intel-QS](https://github.com/iqusoft/intel-qs) and [NVIDIA cuQuantum](https://developer.nvidia.com/cuquantum-sdk), to cloud-based simulators from most of the major quantum cloud providers, like the **_29-qubit cloud simulator available as part of [The IonQ Quantum Cloud](https://ionq.com/docs)."_**

https://ionq.com/posts/november-12-2021-the-value-of-quantum-simulators

I have personally run jobs in the high teens (like 18 qubits) on the Ionq simulator.

I haven't tried anything higher than that because it is very slow.

Please let me know if you need anything to make a decision or clean up the changes I have made.

Thank you!
