### PR TITLE
#147 Fix barrier conversion to qiskit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Update pip
       run: pip install --upgrade pip
     - name: Install black and pylint
-      run: pip install black~=21.6b0 pylint
+      run: pip install black~=22.3 pylint
     - name: Check files are formatted with black
       run: |
         black --check modules/

--- a/modules/pytket-cirq/tests/cirq_convert_test.py
+++ b/modules/pytket-cirq/tests/cirq_convert_test.py
@@ -87,7 +87,7 @@ def test_device() -> None:
 
 def test_parallel_ops() -> None:
     q0, q1, q2 = [cirq.LineQubit(i) for i in range(3)]
-    circ = cirq.Circuit([cirq.ops.ParallelGate(cirq.Y ** 0.3, 3).on(q0, q1, q2)])
+    circ = cirq.Circuit([cirq.ops.ParallelGate(cirq.Y**0.3, 3).on(q0, q1, q2)])
     c_tk = cirq_to_tk(circ)
     assert c_tk.n_gates_of_type(OpType.Ry) == 3
     assert c_tk.n_gates == 3

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
@@ -660,7 +660,7 @@ def _process_model(noise_model: NoiseModel, gate_set: Set[OpType]) -> dict:
             link_errors_qubits.add(q0)
             link_errors_qubits.add(q1)
             # to simulate a worse reverse direction square the fidelity
-            link_errors[(q1, q0)].update({optype: 1 - gate_fid ** 2})
+            link_errors[(q1, q0)].update({optype: 1 - gate_fid**2})
             generic_2q_qerrors_dict[(q0, q1)].append(
                 [error["instructions"], error["probabilities"]]
             )

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
@@ -450,6 +450,9 @@ def append_tk_command_to_qiskit(
         # ILO-BE == DLO-LE; qiskit unitaries are ILO-LE == DLO-BE).
         return qcirc.append(g, qargs=list(reversed(qargs)))
     if optype == OpType.Barrier:
+        for q in args:
+            if q.type == UnitType.bit:
+                raise NotImplementedError("Qiskit Barriers are not defined for classical bits.")
         qargs = [qregmap[q.reg_name][q.index[0]] for q in args]
         g = Barrier(len(args))
         return qcirc.append(g, qargs=qargs)

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
@@ -452,7 +452,9 @@ def append_tk_command_to_qiskit(
     if optype == OpType.Barrier:
         for q in args:
             if q.type == UnitType.bit:
-                raise NotImplementedError("Qiskit Barriers are not defined for classical bits.")
+                raise NotImplementedError(
+                    "Qiskit Barriers are not defined for classical bits."
+                )
         qargs = [qregmap[q.reg_name][q.index[0]] for q in args]
         g = Barrier(len(args))
         return qcirc.append(g, qargs=qargs)

--- a/modules/pytket-qiskit/tests/qiskit_convert_test.py
+++ b/modules/pytket-qiskit/tests/qiskit_convert_test.py
@@ -57,6 +57,12 @@ skip_remote_tests: bool = (
 )
 
 
+def test_barrier_conversion() -> None:
+    with pytest.raises(NotImplementedError):
+        c = Circuit(1, 1)
+        c.add_barrier([0], [0])
+        tk_to_qiskit(c)
+
 def test_convert_circuit_with_complex_params() -> None:
     with pytest.raises(ValueError):
         qiskit_op = PauliSumOp.from_list([("Z", 1j)])

--- a/modules/pytket-qiskit/tests/qiskit_convert_test.py
+++ b/modules/pytket-qiskit/tests/qiskit_convert_test.py
@@ -63,6 +63,7 @@ def test_barrier_conversion() -> None:
         c.add_barrier([0], [0])
         tk_to_qiskit(c)
 
+
 def test_convert_circuit_with_complex_params() -> None:
     with pytest.raises(ValueError):
         qiskit_op = PauliSumOp.from_list([("Z", 1j)])


### PR DESCRIPTION
Fixes #147 

This PR addresses the bug of converting a barrier optype defined over classical bits to Qiskit. It turns out that Qiskit doesn't support `Barrier` for bits. An error is raised in that case. 