### PR TITLE
[pytket-quantinuum] use syntax checkers for cost estimate

### DIFF
--- a/modules/pytket-quantinuum/docs/changelog.rst
+++ b/modules/pytket-quantinuum/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 ~~~~~~~~~
 
+0.3.0 (UNRELEASED)
+----------
+
+* ``QuantinuumBackend.cost_estimate`` deprecated, new ``QuantinuumBackend.cost``
+  method now uses the syntax checker devices to directly return the cost.
+
 0.2.0 (April 2022)
 ------------------
 

--- a/modules/pytket-quantinuum/pytket/extensions/quantinuum/backends/quantinuum.py
+++ b/modules/pytket-quantinuum/pytket/extensions/quantinuum/backends/quantinuum.py
@@ -229,7 +229,12 @@ class QuantinuumBackend(Backend):
         )
         _api_handler._response_check(res, "get machine status")
         jr = res.json()
-        return str(jr["state"])
+        try:
+            return str(jr["state"])
+        except KeyError:
+            # for family backends the response dictionary is different
+            # {"<device_name>": <state>}
+            return str(jr)
 
     @property
     def backend_info(self) -> Optional[BackendInfo]:

--- a/modules/pytket-quantinuum/tests/backend_test.py
+++ b/modules/pytket-quantinuum/tests/backend_test.py
@@ -474,3 +474,9 @@ def test_zzphase(
     res = backend.get_result(handle, timeout=49)
     counts = res.get_counts()
     assert counts == correct_counts
+
+
+@pytest.mark.skipif(skip_remote_tests, reason=REASON)
+@pytest.mark.parametrize("device_name", ALL_DEVICE_NAMES)
+def test_device_state(device_name: str) -> None:
+    assert isinstance(QuantinuumBackend.device_state(device_name), str)


### PR DESCRIPTION
cost_estimate now requires a login to the API

the only questionable part is that the method automatically tries to use the right syntax checker backend for the backend currently in use.