### PR TITLE
Skip checks for PRs with no pytket extension changes

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -144,8 +144,8 @@ jobs:
     needs: set-modules-to-test
     runs-on: macos-11
     if: |
-      (github.event_name == 'pull_request' && needs.set-modules-to-test.outputs.matrix != '[""]')
-      || github.event_name != 'release'
+      (github.event_name == 'pull_request' && needs.set-modules-to-test.outputs.matrix != '[""]') ||
+      (github.event_name != 'release' && github.event_name != 'pull_request')
 
     strategy:
       matrix:
@@ -212,8 +212,8 @@ jobs:
     needs: set-modules-to-test
     runs-on: windows-2019
     if: |
-      (github.event_name == 'pull_request' && needs.set-modules-to-test.outputs.matrix != '[""]')
-      || github.event_name != 'release'
+      (github.event_name == 'pull_request' && needs.set-modules-to-test.outputs.matrix != '[""]') ||
+      (github.event_name != 'release' && github.event_name != 'pull_request')
 
     strategy:
       matrix:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -140,12 +140,12 @@ jobs:
         path: wheelhouse/
 
   macos-checks:
-    if: github.event_name != 'release'
+    if: |
+      github.event_name != 'release' ||
+      ${{ ! ( needs.set-modules-to-test.outputs.matrix == '[""]' && github.event_name == 'pull_request') }}
     name: MacOS - Build and test module
     needs: set-modules-to-test
     runs-on: macos-11
-    # Skip if PR with no changes to pytket extensions
-    if: ${{ ! ( needs.set-modules-to-test.outputs.matrix == '[""]' && github.event_name == 'pull_request') }}
 
     strategy:
       matrix:
@@ -208,12 +208,12 @@ jobs:
         MODULE: ${{ matrix.module }}
 
   windows-checks:
-    if: github.event_name != 'release'
+    if: |
+      github.event_name != 'release' ||
+      ${{ ! ( needs.set-modules-to-test.outputs.matrix == '[""]' && github.event_name == 'pull_request') }}
     name: Windows - Build and test module
     needs: set-modules-to-test
     runs-on: windows-2019
-    # Skip if PR with no changes to pytket extensions
-    if: ${{ ! ( needs.set-modules-to-test.outputs.matrix == '[""]' && github.event_name == 'pull_request') }}
 
     strategy:
       matrix:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -144,7 +144,7 @@ jobs:
     needs: set-modules-to-test
     runs-on: macos-11
     if: |
-      github.event_name != 'release' ||
+      github.event_name != 'release' &&
       ${{ ! ( needs.set-modules-to-test.outputs.matrix == '[""]' && github.event_name == 'pull_request') }}
 
     strategy:
@@ -212,7 +212,7 @@ jobs:
     needs: set-modules-to-test
     runs-on: windows-2019
     if: |
-      github.event_name != 'release' ||
+      github.event_name != 'release' &&
       ${{ ! ( needs.set-modules-to-test.outputs.matrix == '[""]' && github.event_name == 'pull_request') }}
 
     strategy:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -72,6 +72,8 @@ jobs:
     name: Linux - Build and test module
     needs: set-modules-to-test
     runs-on: ubuntu-20.04
+    # Skip if PR with no changes to pytket extensions
+    if: ${{ ! ( needs.set-modules-to-test.outputs.matrix == '[""]' && github.event_name == 'pull_request') }}
 
     strategy:
       matrix:
@@ -142,6 +144,8 @@ jobs:
     name: MacOS - Build and test module
     needs: set-modules-to-test
     runs-on: macos-11
+    # Skip if PR with no changes to pytket extensions
+    if: ${{ ! ( needs.set-modules-to-test.outputs.matrix == '[""]' && github.event_name == 'pull_request') }}
 
     strategy:
       matrix:
@@ -208,6 +212,8 @@ jobs:
     name: Windows - Build and test module
     needs: set-modules-to-test
     runs-on: windows-2019
+    # Skip if PR with no changes to pytket extensions
+    if: ${{ ! ( needs.set-modules-to-test.outputs.matrix == '[""]' && github.event_name == 'pull_request') }}
 
     strategy:
       matrix:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -144,8 +144,8 @@ jobs:
     needs: set-modules-to-test
     runs-on: macos-11
     if: |
-      github.event_name != 'release' &&
-      ${{ ! ( needs.set-modules-to-test.outputs.matrix == '[""]' && github.event_name == 'pull_request') }}
+      (github.event_name == 'pull_request' && needs.set-modules-to-test.outputs.matrix != '[""]')
+      || github.event_name != 'release'
 
     strategy:
       matrix:
@@ -212,8 +212,8 @@ jobs:
     needs: set-modules-to-test
     runs-on: windows-2019
     if: |
-      github.event_name != 'release' &&
-      ${{ ! ( needs.set-modules-to-test.outputs.matrix == '[""]' && github.event_name == 'pull_request') }}
+      (github.event_name == 'pull_request' && needs.set-modules-to-test.outputs.matrix != '[""]')
+      || github.event_name != 'release'
 
     strategy:
       matrix:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -140,12 +140,12 @@ jobs:
         path: wheelhouse/
 
   macos-checks:
-    if: |
-      github.event_name != 'release' ||
-      ${{ ! ( needs.set-modules-to-test.outputs.matrix == '[""]' && github.event_name == 'pull_request') }}
     name: MacOS - Build and test module
     needs: set-modules-to-test
     runs-on: macos-11
+    if: |
+      github.event_name != 'release' ||
+      ${{ ! ( needs.set-modules-to-test.outputs.matrix == '[""]' && github.event_name == 'pull_request') }}
 
     strategy:
       matrix:
@@ -208,12 +208,12 @@ jobs:
         MODULE: ${{ matrix.module }}
 
   windows-checks:
-    if: |
-      github.event_name != 'release' ||
-      ${{ ! ( needs.set-modules-to-test.outputs.matrix == '[""]' && github.event_name == 'pull_request') }}
     name: Windows - Build and test module
     needs: set-modules-to-test
     runs-on: windows-2019
+    if: |
+      github.event_name != 'release' ||
+      ${{ ! ( needs.set-modules-to-test.outputs.matrix == '[""]' && github.event_name == 'pull_request') }}
 
     strategy:
       matrix:


### PR DESCRIPTION
Fix the bug introduced with #362 where the `buid_and_test.yml` fails if a PR has no changes to pytket extensions.