### PR TITLE
[pytket-braket] Handle measurements.

### DIFF
--- a/modules/pytket-braket/docs/changelog.rst
+++ b/modules/pytket-braket/docs/changelog.rst
@@ -5,6 +5,8 @@ Changelog
 -------------------
 
 * Add optional "aws_session" parameter to the available_devices class method of BracketBackend.
+* Respect measurement operations in submitted circuits. (Previously these were
+  not allowed and measurements were automatically added to all qubits.)
 
 0.18.0 (April 2022)
 -------------------

--- a/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
+++ b/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
@@ -226,7 +226,7 @@ def _get_result(
             else:
                 kwargs["density_matrix"] = m
     else:
-        target_bits = [measures[i] for i in target_qubits]
+        target_bits = [measures[i] for i in target_qubits if i in measures]
         measurements = result.measurements[:, target_bits]
         kwargs["shots"] = OutcomeArray.from_readouts(measurements)
         kwargs["ppcirc"] = ppcirc

--- a/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
+++ b/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
@@ -621,7 +621,9 @@ class BraketBackend(Backend):
         else:
             return self._device.run(bkcirc, self._s3_dest, shots=n_shots, **kwargs)
 
-    def _to_bkcirc(self, circuit: Circuit) -> braket.circuits.Circuit:
+    def _to_bkcirc(
+        self, circuit: Circuit
+    ) -> Tuple[braket.circuits.Circuit, Dict[int, int]]:
         if self._device_type == _DeviceType.QPU:
             return tk_to_braket(circuit, self._all_qubits)
         else:
@@ -677,7 +679,7 @@ class BraketBackend(Backend):
                 ppcirc_rep = ppcirc.to_dict()
             else:
                 c0, ppcirc, ppcirc_rep = circ, None, None
-            bkcirc = self._to_bkcirc(c0)
+            bkcirc, _ = self._to_bkcirc(c0)
             if want_state:
                 bkcirc.add_result_type(ResultType.StateVector())
             if want_dm:
@@ -933,7 +935,7 @@ class BraketBackend(Backend):
         """
         if valid_check:
             self._check_all_circuits([state_circuit], nomeasure_warn=False)
-        bkcirc = self._to_bkcirc(state_circuit)
+        bkcirc, _ = self._to_bkcirc(state_circuit)
         observable, qbs = _obs_from_qps(pauli)
         return self._get_expectation_value(bkcirc, observable, qbs, n_shots, **kwargs)
 
@@ -957,7 +959,7 @@ class BraketBackend(Backend):
         """
         if valid_check:
             self._check_all_circuits([state_circuit], nomeasure_warn=False)
-        bkcirc = self._to_bkcirc(state_circuit)
+        bkcirc, _ = self._to_bkcirc(state_circuit)
         observable = _obs_from_qpo(operator, state_circuit.n_qubits)
         return self._get_expectation_value(
             bkcirc, observable, bkcirc.qubits, n_shots, **kwargs
@@ -983,7 +985,7 @@ class BraketBackend(Backend):
         """
         if valid_check:
             self._check_all_circuits([state_circuit], nomeasure_warn=False)
-        bkcirc = self._to_bkcirc(state_circuit)
+        bkcirc, _ = self._to_bkcirc(state_circuit)
         observable, qbs = _obs_from_qps(pauli)
         return self._get_variance(bkcirc, observable, qbs, n_shots, **kwargs)
 
@@ -1007,7 +1009,7 @@ class BraketBackend(Backend):
         """
         if valid_check:
             self._check_all_circuits([state_circuit], nomeasure_warn=False)
-        bkcirc = self._to_bkcirc(state_circuit)
+        bkcirc, _ = self._to_bkcirc(state_circuit)
         observable = _obs_from_qpo(operator, state_circuit.n_qubits)
         return self._get_variance(bkcirc, observable, bkcirc.qubits, n_shots, **kwargs)
 
@@ -1049,7 +1051,7 @@ class BraketBackend(Backend):
             )
         if valid_check:
             self._check_all_circuits([circuit], nomeasure_warn=False)
-        bkcirc = self._to_bkcirc(circuit)
+        bkcirc, _ = self._to_bkcirc(circuit)
         restype = ResultType.Probability(target=qubits)
         bkcirc.add_result_type(restype)
         task = self._run(bkcirc, n_shots=n_shots, **kwargs)
@@ -1076,7 +1078,7 @@ class BraketBackend(Backend):
             raise RuntimeError("Backend does not support amplitude")
         if valid_check:
             self._check_all_circuits([circuit], nomeasure_warn=False)
-        bkcirc = self._to_bkcirc(circuit)
+        bkcirc, _ = self._to_bkcirc(circuit)
         restype = ResultType.Amplitude(states)
         bkcirc.add_result_type(restype)
         task = self._run(bkcirc, n_shots=0, **kwargs)

--- a/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
+++ b/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import json
-from ast import literal_eval
 from enum import Enum
 import time
 from typing import (
@@ -708,7 +707,7 @@ class BraketBackend(Backend):
                 handle = ResultHandle(
                     task.id,
                     json.dumps(target_qubits),
-                    str(measures),
+                    json.dumps(list(measures.items())),
                     want_state,
                     want_dm,
                     json.dumps(ppcirc_rep),
@@ -717,7 +716,7 @@ class BraketBackend(Backend):
                 handle = ResultHandle(
                     str(uuid4()),
                     json.dumps(target_qubits),
-                    str(measures),
+                    json.dumps(list(measures.items())),
                     False,
                     False,
                     json.dumps(None),
@@ -752,7 +751,7 @@ class BraketBackend(Backend):
                 _get_result(
                     task,
                     json.loads(target_qubits),
-                    literal_eval(measures),
+                    dict(json.loads((measures))),
                     want_state,
                     want_dm,
                     ppcirc,

--- a/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
+++ b/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
@@ -226,8 +226,8 @@ def _get_result(
             else:
                 kwargs["density_matrix"] = m
     else:
-        target_bits = [measures[i] for i in target_qubits if i in measures]
-        measurements = result.measurements[:, target_bits]
+        qubits_index = [measures[i] for i in target_qubits if i in measures]
+        measurements = result.measurements[:, qubits_index]
         kwargs["shots"] = OutcomeArray.from_readouts(measurements)
         kwargs["ppcirc"] = ppcirc
     return {"result": BackendResult(**kwargs)}

--- a/modules/pytket-braket/pytket/extensions/braket/braket_convert.py
+++ b/modules/pytket-braket/pytket/extensions/braket/braket_convert.py
@@ -41,30 +41,36 @@ def tk_to_braket(
     """
     Convert a tket :py:class:`Circuit` to a braket circuit.
 
-    `tkcirc` must be a circuit having a single one-dimensional register of qubits.
+    If `allqbs` is provided then `tkcirc` must be a circuit having a single
+    one-dimensional register of qubits.
+
     If `allqbs` is not provided then it is taken to be the qubit set of `tkcirc`.
+
     The resulting circuit will begin with an identity gate on all qubits in `allqbs`.
     This is to work around a quirk in braket where circuits whose qubit set contains
     gaps are rejected.
 
-    Any Measure gates present in the circuit are ignored.
-
     :param tkcirc: circuit to be converted
-    :param allqbs: all qubits on braket device (superset of indices of tkcirc qubits)
+    :param allqbs: superset of indices of tkcirc qubits, if those have been mapped to a
+        braked QPU device
 
     :returns: circuit converted to braket, and dictionary of measurements (from bit
         indices to qubit indices)
     """
     bkcirc = BK_Circuit()
-    if allqbs is None:
-        allqbs = [qb.index[0] for qb in tkcirc.qubits]
+    mapped_qubits = allqbs is not None
+    if not mapped_qubits:
+        allqbs = range(tkcirc.n_qubits)
     for qb in allqbs:
         bkcirc.i(qb)
     measures = {}
     # Add commands
     for cmd in tkcirc.get_commands():
-        qbs = [qb.index[0] for qb in cmd.qubits]
-        cbs = [cb.index[0] for cb in cmd.bits]
+        qbs = [
+            qb.index[0] if mapped_qubits else tkcirc.qubits.index(qb)
+            for qb in cmd.qubits
+        ]
+        cbs = [tkcirc.bits.index(cb) for cb in cmd.bits]
         op = cmd.op
         optype = op.type
         params = op.params

--- a/modules/pytket-braket/pytket/extensions/braket/braket_convert.py
+++ b/modules/pytket-braket/pytket/extensions/braket/braket_convert.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Conversion from tket to AQT
+""" Conversion from tket to braket
 """
 
 from typing import (

--- a/modules/pytket-braket/pytket/extensions/braket/braket_convert.py
+++ b/modules/pytket-braket/pytket/extensions/braket/braket_convert.py
@@ -35,7 +35,9 @@ if TYPE_CHECKING:
     from pytket.circuit import Node  # type: ignore
 
 
-def tk_to_braket(tkcirc: Circuit, allqbs: Optional[Iterable[int]] = None) -> BK_Circuit:
+def tk_to_braket(
+    tkcirc: Circuit, allqbs: Optional[Iterable[int]] = None
+) -> Tuple[BK_Circuit, Dict[int, int]]:
     """
     Convert a tket :py:class:`Circuit` to a braket circuit.
 
@@ -50,16 +52,19 @@ def tk_to_braket(tkcirc: Circuit, allqbs: Optional[Iterable[int]] = None) -> BK_
     :param tkcirc: circuit to be converted
     :param allqbs: all qubits on braket device (superset of indices of tkcirc qubits)
 
-    :returns: circuit converted to braket
+    :returns: circuit converted to braket, and dictionary of measurements (from bit
+        indices to qubit indices)
     """
     bkcirc = BK_Circuit()
     if allqbs is None:
         allqbs = [qb.index[0] for qb in tkcirc.qubits]
     for qb in allqbs:
         bkcirc.i(qb)
+    measures = {}
     # Add commands
     for cmd in tkcirc.get_commands():
         qbs = [qb.index[0] for qb in cmd.qubits]
+        cbs = [cb.index[0] for cb in cmd.bits]
         op = cmd.op
         optype = op.type
         params = op.params
@@ -120,12 +125,11 @@ def tk_to_braket(tkcirc: Circuit, allqbs: Optional[Iterable[int]] = None) -> BK_
         elif optype == OpType.ZZPhase:
             bkcirc.zz(*qbs, params[0] * pi)
         elif optype == OpType.Measure:
-            # Not wanted by braket, but may have been introduced by contextual
-            # optimization: ignore.
-            pass
+            # Not wanted by braket, but must be tracked for final conversion of results.
+            measures[cbs[0]] = qbs[0]
         else:
             raise NotImplementedError(f"Cannot convert {op.get_name()} to braket")
-    return bkcirc
+    return (bkcirc, measures)
 
 
 def braket_to_tk(bkcirc: BK_Circuit) -> Circuit:

--- a/modules/pytket-braket/pytket/extensions/braket/braket_convert.py
+++ b/modules/pytket-braket/pytket/extensions/braket/braket_convert.py
@@ -61,6 +61,7 @@ def tk_to_braket(
     mapped_qubits = allqbs is not None
     if not mapped_qubits:
         allqbs = range(tkcirc.n_qubits)
+    assert allqbs is not None
     for qb in allqbs:
         bkcirc.i(qb)
     measures = {}

--- a/modules/pytket-braket/tests/backend_test.py
+++ b/modules/pytket-braket/tests/backend_test.py
@@ -46,6 +46,7 @@ def test_simulator(authenticated_braket_backend: BraketBackend) -> None:
     b = authenticated_braket_backend
     assert b.supports_shots
     c = Circuit(2).H(0).CX(0, 1)
+    c.measure_all()
     c = b.get_compiled_circuit(c)
     n_shots = 100
     h0, h1 = b.process_circuits([c, c], n_shots)
@@ -63,6 +64,7 @@ def test_simulator(authenticated_braket_backend: BraketBackend) -> None:
 
     # Circuit with unused qubits
     c = Circuit(3).H(1).CX(1, 2)
+    c.measure_all()
     c = b.get_compiled_circuit(c)
     h = b.process_circuit(c, 1)
     res = b.get_result(h)
@@ -99,6 +101,7 @@ def test_tn1_simulator(authenticated_braket_backend: BraketBackend) -> None:
     b = authenticated_braket_backend
     assert b.supports_shots
     c = Circuit(2).H(0).CX(0, 1)
+    c.measure_all()
     c = b.get_compiled_circuit(c)
     n_shots = 100
     h0, h1 = b.process_circuits([c, c], n_shots)
@@ -111,6 +114,7 @@ def test_tn1_simulator(authenticated_braket_backend: BraketBackend) -> None:
     assert sum(counts.values()) == n_shots
     # Circuit with unused qubits
     c = Circuit(3).H(1).CX(1, 2)
+    c.measure_all()
     c = b.get_compiled_circuit(c)
     h = b.process_circuit(c, 1)
     res = b.get_result(h)
@@ -284,6 +288,7 @@ def test_local_simulator() -> None:
     assert b.supports_shots
     assert b.supports_counts
     c = Circuit(2).H(0).CX(0, 1)
+    c.measure_all()
     c = b.get_compiled_circuit(c)
     n_shots = 100
     h = b.process_circuit(c, n_shots)
@@ -390,6 +395,7 @@ def test_probabilities() -> None:
 def test_probabilities_with_shots() -> None:
     b = BraketBackend(local=True)
     c = Circuit(2).V(1).CX(1, 0).S(1)
+    c.measure_all()
     probs_all = b.get_probabilities(c, n_shots=10)
     assert len(probs_all) == 4
     assert sum(probs_all) == pytest.approx(1)
@@ -444,6 +450,7 @@ def test_default_pass() -> None:
 def test_shots_bits_edgecases(n_shots, n_bits) -> None:
     braket_backend = BraketBackend(local=True)
     c = Circuit(n_bits, n_bits)
+    c.measure_all()
 
     # TODO TKET-813 add more shot based backends and move to integration tests
     h = braket_backend.process_circuit(c, n_shots)
@@ -474,9 +481,10 @@ def test_postprocess_ionq(authenticated_braket_backend: BraketBackend) -> None:
     b = authenticated_braket_backend
     assert b.supports_contextual_optimisation
     c = Circuit(2).H(0).CX(0, 1).Y(0)
+    c.measure_all()
     c = b.get_compiled_circuit(c)
     h = b.process_circuit(c, n_shots=10, postprocess=True)
-    ppcirc = Circuit.from_dict(json.loads(cast(str, h[4])))
+    ppcirc = Circuit.from_dict(json.loads(cast(str, h[5])))
     ppcmds = ppcirc.get_commands()
     assert len(ppcmds) > 0
     assert all(ppcmd.op.type == OpType.ClassicalTransform for ppcmd in ppcmds)

--- a/modules/pytket-braket/tests/backend_test.py
+++ b/modules/pytket-braket/tests/backend_test.py
@@ -505,3 +505,20 @@ def test_retrieve_available_devices(
         region="us-west-2", aws_session=authenticated_braket_backend._aws_session
     )
     assert len(backend_infos) > 0
+
+
+def test_partial_measurement() -> None:
+    b = BraketBackend(local=True)
+    c = Circuit(4, 4)
+    c.H(0).CX(0, 1)
+    c.Measure(0, 1)
+    c.Measure(2, 0)
+    c = b.get_compiled_circuit(c)
+    n_shots = 100
+    h = b.process_circuit(c, n_shots)
+    res = b.get_result(h)
+    readouts = res.get_shots()
+    assert all(len(readouts[i]) == 2 for i in range(n_shots))
+    assert all(readouts[i][0] == 0 for i in range(n_shots))
+    counts = res.get_counts()
+    assert sum(counts.values()) == n_shots

--- a/modules/pytket-braket/tests/convert_test.py
+++ b/modules/pytket-braket/tests/convert_test.py
@@ -45,14 +45,14 @@ def test_convert() -> None:
     c.add_gate(OpType.YYPhase, 0.8, [0, 1])
     c.add_gate(OpType.Z, [0])
     c.add_gate(OpType.ZZPhase, 0.9, [0, 1])
-    bkc = tk_to_braket(c)
+    bkc, _ = tk_to_braket(c)
     c1 = braket_to_tk(bkc)
     assert c.get_commands() == c1.get_commands()
 
 
 def test_convert_qubit_order() -> None:
     c = Circuit(3).H(2).CX(2, 1)
-    bkc = tk_to_braket(c)
+    bkc, _ = tk_to_braket(c)
     c1 = braket_to_tk(bkc)
     assert c.get_commands() == c1.get_commands()
 


### PR DESCRIPTION
Fixes #375 .

Currently we ignore measurement operations in tket circuits, since braket automatically measures everything. But we need to be able to handle circuits where not all qubits are measured. Here we keep track of the measurement mappings in a dictionary encoded in the result handle.