### PR TITLE
[feature] [pytket-ionq] use api for ionq device info

### DIFF
--- a/modules/pytket-ionq/docs/changelog.rst
+++ b/modules/pytket-ionq/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 ~~~~~~~~~
 
+
+0.18.0 (Unreleased)
+-------------------
+
+* Retrieve device info from API, requires valid API token to initialize ``IonQBackend``.
+
+
 0.17.0 (April 2022)
 -------------------
 
@@ -66,4 +73,3 @@ Changelog
 ----------------
 
 * Contextual optimisation added to default compilation passes (except at optimisation level 0).
-

--- a/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq.py
+++ b/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import cast, Optional, List, Sequence, Union, Counter, Any
+from typing import Dict, cast, Optional, List, Sequence, Union, Counter, Any
 import json
 import time
 from ast import literal_eval
@@ -53,7 +53,6 @@ from .config import IonQConfig
 
 IONQ_JOBS_URL = "https://api.ionq.co/v0.1/jobs/"
 
-IONQ_N_QUBITS = 11
 
 _STATUS_MAP = {
     "completed": StatusEnum.COMPLETED,
@@ -91,6 +90,7 @@ class IonQBackend(Backend):
         device_name: str = "qpu",
         api_key: Optional[str] = None,
         label: Optional[str] = "job",
+        _machine_debug: bool = False,
     ):
         """
         Construct a new IonQ backend.
@@ -106,39 +106,64 @@ class IonQBackend(Backend):
         super().__init__()
         self._url = IONQ_JOBS_URL
         self._label = label
-        config = IonQConfig.from_default_config_file()
-
-        if api_key is None:
-            api_key = config.api_key
-        if api_key is None:
-            raise IonQAuthenticationError()
-
-        self._header = {"Authorization": f"apiKey {api_key}"}
-        self._backend_info = fully_connected_backendinfo(
-            type(self).__name__,
-            device_name,
-            __extension_version__,
-            IONQ_N_QUBITS,
-            ionq_gates,
-        )
-        self._qm = {Qubit(i): node for i, node in enumerate(self._backend_info.nodes)}
-        self._MACHINE_DEBUG = False
+        self._MACHINE_DEBUG = _machine_debug
+        self._backend_info = self._available_devices(self._MACHINE_DEBUG, api_key)[
+            device_name
+        ]
+        self._header = self._get_header(api_key)
 
     @property
     def backend_info(self) -> Optional[BackendInfo]:
         return self._backend_info
 
+    @staticmethod
+    def _get_header(api_key: Optional[str] = None) -> Dict[str, str]:
+
+        if api_key is None:
+            config = IonQConfig.from_default_config_file()
+            api_key = config.api_key
+        if api_key is None:
+            raise IonQAuthenticationError()
+
+        return {"Authorization": f"apiKey {api_key}"}
+
+    @classmethod
+    def _available_devices(
+        cls, debug: bool, api_key: Optional[str] = None
+    ) -> Dict[str, BackendInfo]:
+        if debug:
+            return {
+                "simulator": fully_connected_backendinfo(
+                    cls.__name__,
+                    "simulator",
+                    __extension_version__,
+                    11,
+                    ionq_gates,
+                )
+            }
+        resp = get(
+            "https://api.ionq.co/v0.2/backends",
+            headers=IonQBackend._get_header(api_key),
+        ).json()
+
+        if "error" in resp:
+            raise RuntimeError(resp["error"])
+
+        return {
+            dev["backend"]: fully_connected_backendinfo(
+                cls.__name__,
+                dev["backend"],
+                __extension_version__,
+                int(dev["qubits"]),
+                ionq_gates,
+                misc=dev,
+            )
+            for dev in resp
+        }
+
     @classmethod
     def available_devices(cls, **kwargs: Any) -> List[BackendInfo]:
-        return [
-            fully_connected_backendinfo(
-                cls.__name__,
-                "qpu",
-                __extension_version__,
-                IONQ_N_QUBITS,
-                ionq_gates,
-            )
-        ]
+        return list(cls._available_devices(False, **kwargs).values())
 
     @property
     def required_predicates(self) -> List[Predicate]:
@@ -157,12 +182,14 @@ class IonQBackend(Backend):
 
     def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:
         assert optimisation_level in range(3)
+        _qm = {Qubit(i): node for i, node in enumerate(self._backend_info.nodes)}
+
         if optimisation_level == 0:
             return SequencePass(
                 [
                     DecomposeBoxes(),
                     FlattenRegisters(),
-                    RenameQubitsPass(self._qm),
+                    RenameQubitsPass(_qm),
                     self.rebase_pass(),
                 ]
             )
@@ -172,7 +199,7 @@ class IonQBackend(Backend):
                     DecomposeBoxes(),
                     SynthesiseTket(),
                     FlattenRegisters(),
-                    RenameQubitsPass(self._qm),
+                    RenameQubitsPass(_qm),
                     self.rebase_pass(),
                     SimplifyInitial(allow_classical=False, create_all_qubits=True),
                 ]
@@ -183,7 +210,7 @@ class IonQBackend(Backend):
                     DecomposeBoxes(),
                     FullPeepholeOptimise(),
                     FlattenRegisters(),
-                    RenameQubitsPass(self._qm),
+                    RenameQubitsPass(_qm),
                     self.rebase_pass(),
                     SquashCustom(
                         ionq_singleqs,

--- a/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq_convert.py
+++ b/modules/pytket-ionq/pytket/extensions/ionq/backends/ionq_convert.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 from typing import Dict, Tuple, Any, List
+from numpy import pi
 from pytket.passes import RebaseCustom  # type: ignore
 from pytket._tket.circuit._library import _TK1_to_RzRx  # type: ignore
 from pytket.circuit import Circuit, OpType, Command  # type: ignore
-from numpy import pi
 
 
 ionq_multiqs = {


### PR DESCRIPTION
follow on for https://github.com/CQCL/pytket-extensions/pull/346

Use the Ionq  API to retrieve relevant device info

this now means authentication is required to initialise the backend so update use of machine debug to compensate.