### PR TITLE
[pytket-braket] add additional cancelling status for braket

### DIFF
--- a/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
+++ b/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
@@ -745,7 +745,7 @@ class BraketBackend(Backend):
         state = task.state()
         if state == "FAILED":
             return CircuitStatus(StatusEnum.ERROR, task.metadata()["failureReason"])
-        elif state == "CANCELLED":
+        elif state in ["CANCELLED", "CANCELLING"]:
             return CircuitStatus(StatusEnum.CANCELLED)
         elif state == "COMPLETED":
             self._update_cache_result(


### PR DESCRIPTION
When doing constant polling for status there is an additional status which is not handled by StatusEnum.Cancelled 
Which ends up being handled by this [line](https://github.com/CQCL/pytket-extensions/blob/develop/modules/pytket-braket/pytket/extensions/braket/backends/braket.py#L768)
`Unrecognized state 'CANCELLING'`

Let me know if you'd like other behavior in handling this status.
Thanks!