### PR TITLE
[pytket-braket] fix  _all_qubits for Lucy

### DIFF
--- a/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
+++ b/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
@@ -316,7 +316,9 @@ class BraketBackend(Backend):
                 "arn:aws:braket:"
                 + region
                 + "::"
-                + "/".join(["device", device_type, provider, device],),
+                + "/".join(
+                    ["device", device_type, provider, device],
+                ),
                 aws_session=self._aws_session,
             )
             self._s3_dest = (s3_bucket, s3_folder)
@@ -380,7 +382,11 @@ class BraketBackend(Backend):
         if self._device_type == _DeviceType.QPU:
             self._characteristics = props["provider"]
         self._backend_info = self._get_backend_info(
-            arch, device, self._singleqs, self._multiqs, self._characteristics,
+            arch,
+            device,
+            self._singleqs,
+            self._multiqs,
+            self._characteristics,
         )
 
         paradigm = props["paradigm"]
@@ -402,9 +408,14 @@ class BraketBackend(Backend):
             self._req_preds.append(ConnectivityPredicate(arch))
 
         self._rebase_pass = RebaseCustom(
-            self._multiqs | self._singleqs, Circuit(), _TK1_to_RzRx,
+            self._multiqs | self._singleqs,
+            Circuit(),
+            _TK1_to_RzRx,
         )
-        self._squash_pass = SquashCustom(self._singleqs, _TK1_to_RzRx,)
+        self._squash_pass = SquashCustom(
+            self._singleqs,
+            _TK1_to_RzRx,
+        )
 
     @staticmethod
     def _get_gate_set(
@@ -835,7 +846,11 @@ class BraketBackend(Backend):
             if device_type == _DeviceType.QPU:
                 characteristics = props["provider"]
             backend_info = cls._get_backend_info(
-                arch, device["deviceName"], singleqs, multiqs, characteristics,
+                arch,
+                device["deviceName"],
+                singleqs,
+                multiqs,
+                characteristics,
             )
             backend_infos.append(backend_info)
         return backend_infos

--- a/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
+++ b/modules/pytket-braket/pytket/extensions/braket/backends/braket.py
@@ -316,9 +316,7 @@ class BraketBackend(Backend):
                 "arn:aws:braket:"
                 + region
                 + "::"
-                + "/".join(
-                    ["device", device_type, provider, device],
-                ),
+                + "/".join(["device", device_type, provider, device],),
                 aws_session=self._aws_session,
             )
             self._s3_dest = (s3_bucket, s3_folder)
@@ -382,11 +380,7 @@ class BraketBackend(Backend):
         if self._device_type == _DeviceType.QPU:
             self._characteristics = props["provider"]
         self._backend_info = self._get_backend_info(
-            arch,
-            device,
-            self._singleqs,
-            self._multiqs,
-            self._characteristics,
+            arch, device, self._singleqs, self._multiqs, self._characteristics,
         )
 
         paradigm = props["paradigm"]
@@ -408,14 +402,9 @@ class BraketBackend(Backend):
             self._req_preds.append(ConnectivityPredicate(arch))
 
         self._rebase_pass = RebaseCustom(
-            self._multiqs | self._singleqs,
-            Circuit(),
-            _TK1_to_RzRx,
+            self._multiqs | self._singleqs, Circuit(), _TK1_to_RzRx,
         )
-        self._squash_pass = SquashCustom(
-            self._singleqs,
-            _TK1_to_RzRx,
-        )
+        self._squash_pass = SquashCustom(self._singleqs, _TK1_to_RzRx,)
 
     @staticmethod
     def _get_gate_set(
@@ -459,7 +448,16 @@ class BraketBackend(Backend):
                 connectivity_graph = dict(
                     (int(k), [int(v) for v in l]) for k, l in connectivity_graph.items()
                 )
-                all_qubits = sorted(connectivity_graph.keys())
+                # each connectivity graph key will be an int
+                # connectivity_graph values will be lists
+                qubit_list = [
+                    [*connectivity_graph.keys()],
+                    *connectivity_graph.values(),
+                ]
+                # summing lists will flatten them
+                # example [[0,1], [0,2]] would be [0,1,0,2] when summed
+                # returns unique ordered list since taking set of sum
+                all_qubits = list(set(sum(qubit_list, [])))
                 if n_qubits < len(all_qubits):
                     # This can happen, at least on rigetti devices, and causes errors.
                     # As a kludgy workaround, remove some qubits from the architecture.
@@ -837,11 +835,7 @@ class BraketBackend(Backend):
             if device_type == _DeviceType.QPU:
                 characteristics = props["provider"]
             backend_info = cls._get_backend_info(
-                arch,
-                device["deviceName"],
-                singleqs,
-                multiqs,
-                characteristics,
+                arch, device["deviceName"], singleqs, multiqs, characteristics,
             )
             backend_infos.append(backend_info)
         return backend_infos


### PR DESCRIPTION
To fix issue related to Lucy backend _all_qubits issue reference in #382.
self._all_qubits
```
[0, 1, 2, 4, 6, 7]
```
<img width="200" alt="Screen Shot 2022-05-12 at 2 50 55 AM" src="https://user-images.githubusercontent.com/18612545/168020545-139796c4-cbbb-4d47-8ec1-d3de2c00e5b6.png">

Missing the 3 and 5.
This causes issues with the conversion to braket circuit via this [method](https://github.com/CQCL/pytket-extensions/blob/develop/modules/pytket-braket/pytket/extensions/braket/backends/braket.py#L635)
When getting measures back from the results will only have the 6 qubits rather than 8 qubits for the samples.

Solution pulls all nodes in connectivity graph flattens them and then uses the set operator to get unique ordered list.
Now should return
self._all_qubits
```
[0, 1, 2, 3, 4, 5, 6, 7]
```

Please let me know if there is anything I can do