### PR TITLE
[pytket-quantinuum] Catch ValueError for uvloop

### DIFF
--- a/modules/pytket-quantinuum/pytket/extensions/quantinuum/backends/api_wrappers.py
+++ b/modules/pytket-quantinuum/pytket/extensions/quantinuum/backends/api_wrappers.py
@@ -33,7 +33,7 @@ from .credential_storage import MemoryCredentialStorage
 # This is necessary for use in Jupyter notebooks to allow for nested asyncio loops
 try:
     nest_asyncio.apply()
-except RuntimeError:
+except (RuntimeError, ValueError):
     # May fail in some cloud environments: ignore.
     pass
 


### PR DESCRIPTION
When using nest_asyncio in the context of alternative event loops such as `uvloop`, `nest_asyncio.apply()` will raise a ValueError rather than a RuntimeError. For example:

```
ValueError: Can't patch loop of type <class 'uvloop.Loop'>
```


This commit adds ValueError to the `except` block in pytket-quantinuum to ignore this error and continue.