### PR TITLE
Remove constraint on qcs-api-client.

### DIFF
--- a/modules/pytket-pyquil/setup.py
+++ b/modules/pytket-pyquil/setup.py
@@ -41,7 +41,6 @@ setup(
     install_requires=[
         "pytket ~= 1.3",
         "pyquil ~= 3.1",
-        "qcs-api-client < 0.20.14",
         "typing-extensions ~= 4.2",
     ],
     classifiers=[


### PR DESCRIPTION
Solves https://github.com/CQCL/pytket/issues/153 by allowing pyjwt 2.4 to be installed with pytket-pyquil.