### PR TITLE
[feature] [pytket-quantinuum] add new simpler batching interface

### DIFF
--- a/modules/pytket-quantinuum/docs/changelog.rst
+++ b/modules/pytket-quantinuum/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 ~~~~~~~~~
 
+0.6.0 (Unreleased)
+------------------
+
+* Changed batching interface: `process_circuits` no longer batches, use
+  `start_batching` and `add_to_batch` methods to explicitly start and append to
+  batches.
+
 0.5.0 (July 2022)
 -----------------
 

--- a/modules/pytket-quantinuum/docs/intro.txt
+++ b/modules/pytket-quantinuum/docs/intro.txt
@@ -119,13 +119,41 @@ The ``process_circuits`` method for the QuantinuumBackend accepts the following 
 *  ``noisy_simulation`` : boolean flag to specify whether the simulator should
    perform noisy simulation with an error model (default value is ``True``).
 *  ``group`` : string identifier of a collection of jobs, can be used for usage tracking.
-*  ``max_batch_cost``: maximum HQC usable by submitted batch, default is 500.
-*  ``batch_id`` : first ``jobid`` of the batch to which this batch of circuits should be submitted. Job IDs can be retrieved from ResultHandle using ``backend.get_jobid(handle)``.
-*  ``close_batch`` : boolean flag to close the batch after the last circuit in the job (default value is ``True``).
 
 For the Quantinuum ``Backend``, ``process_circuits`` returns a ``ResultHandle`` object containing a ``job_id`` and a postprocessing ( ``ppcirc``) circuit if there is one.
 
 The ``logout()`` method clears stored JSON web tokens and the user will have to sign in again to access the Quantinuum API.
+
+Batching
+--------
+Quantinuum backends (except syntax checkers) support batching of jobs (circuits). To create
+a batch of jobs, users submit the first job, then signal that subsequent jobs should
+be added to the same batch using the handle of the first. The backend queue
+management system will start the batch as soon as the first job reaches the
+front of the queue and ensure subsequent batch jobs are run one after the other,
+until the end of the batch is reached or there are no new jobs added to the batch
+for ~1 min (at which point the batch expires and any subsequent jobs will be
+added to the standard queue). 
+
+The standard ``process_circuits`` method **no
+longer batches by default**. To use batching first start the batch with
+``start_batch``, which has a similar interface to ``process_circuit`` but with
+an extra first argument `max_batch_cost`:
+
+::
+  
+  h1 = backend.start_batch(max_batch_cost=300, circuit=circuit, n_shots=100)
+
+Add to the batch with subsequent calls of ``add_to_batch`` which takes as first
+argument the handle of the first job of the batch, and has the optional keyword
+argument `batch_end` to signal the end of a batch (default `False`).
+
+::
+
+  h2 = backend.add_to_batch(h1, circuit_2, n_shots=100)
+  h3 = backend.add_to_batch(h1, circuit_3, n_shots=100, batch_end=True)
+
+
 
 .. toctree::
     api.rst

--- a/modules/pytket-quantinuum/tests/backend_test.py
+++ b/modules/pytket-quantinuum/tests/backend_test.py
@@ -387,7 +387,7 @@ def test_shots_bits_edgecases(n_shots, n_bits) -> None:
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.parametrize(
-    "authenticated_quum_backend", [{"device_name": "H1-1E"}], indirect=True
+    "authenticated_quum_backend", [{"device_name": "H1-2E"}], indirect=True
 )
 def test_simulator(
     authenticated_quum_handler: QuantinuumAPI,
@@ -397,7 +397,7 @@ def test_simulator(
     n_shots = 1000
     state_backend = authenticated_quum_backend
     stabilizer_backend = QuantinuumBackend(
-        "H1-1E", simulator="stabilizer", _api_handler=authenticated_quum_handler
+        "H1-2E", simulator="stabilizer", _api_handler=authenticated_quum_handler
     )
 
     circ = state_backend.get_compiled_circuit(circ)
@@ -453,7 +453,7 @@ def test_retrieve_available_devices(
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.parametrize(
-    "authenticated_quum_backend", [{"device_name": "H1-1E"}], indirect=True
+    "authenticated_quum_backend", [{"device_name": "H1-2E"}], indirect=True
 )
 def test_batching(
     authenticated_quum_backend: QuantinuumBackend,
@@ -461,17 +461,13 @@ def test_batching(
     circ = Circuit(2, name="batching_test").H(0).CX(0, 1).measure_all()
     state_backend = authenticated_quum_backend
     circ = state_backend.get_compiled_circuit(circ)
-
-    handles = state_backend.process_circuits([circ, circ], 10)
-    assert state_backend.get_results(handles)
-
     # test batch can be resumed
 
-    [h1, _] = state_backend.process_circuits([circ, circ], 10, close_batch=False)
+    h1 = state_backend.start_batch(500, circ, 10)
+    h2 = state_backend.add_to_batch(h1, circ, 10)
+    h3 = state_backend.add_to_batch(h1, circ, 10, batch_end=True)
 
-    h2 = state_backend.process_circuit(circ, 10, batch_id=state_backend.get_jobid(h1))
-
-    assert state_backend.get_results([h1, h2])
+    assert state_backend.get_results([h1, h2, h3])
 
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)


### PR DESCRIPTION
The Quantinuum batching system is not  a good fit for process_circuits as an interface, and the way of doing it with keyword arguments was getting cumbersome. This simplifies things, at the cost of no longer matching a generic interface. It also fixes an existing bug where one could not start a batch by submitting just a single circuit.