### PR TITLE
Feature/improve state unitary retrieval for aer and qulacs

### DIFF
--- a/modules/pytket-qiskit/docs/changelog.rst
+++ b/modules/pytket-qiskit/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 0.28.0 (unreleased)
 -------------------
 
+* Improve result retrieval speed of ``AerUnitaryBackend`` and ``AerStateBackend``.
 * Update qiskit version to 0.37.
 
 0.27.0 (July 2022)

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/aer.py
@@ -159,22 +159,23 @@ class _AerBaseBackend(Backend):
         circuit_batches, batch_order = _batch_circuits(circuits, n_shots_list)
 
         for (n_shots, batch), indices in zip(circuit_batches, batch_order):
-            if self._backend_info.device_name == "aer_simulator_statevector":
-                qcs = [
-                    tk_to_qiskit(tkc, reverse_index=True, replace_implicit_swaps=True)
-                    for tkc in batch
-                ]
-                for qc in qcs:
-                    qc.save_state()
-            elif self._backend_info.device_name == "aer_simulator_unitary":
-                qcs = [
-                    tk_to_qiskit(tkc, reverse_index=True, replace_implicit_swaps=True)
-                    for tkc in batch
-                ]
-                for qc in qcs:
-                    qc.save_unitary()
-            else:
-                qcs = [tk_to_qiskit(tkc) for tkc in batch]
+        if self.supports_state:
+            reverse_index, replace_implicit_swaps = (True, True)
+            for qc in qcs:
+                qc.save_state()
+
+        elif self.supports_unitary:
+            reverse_index, replace_implicit_swaps = (True, True)
+            for qc in qcs:
+                qc.save_unitary()
+
+        qcs = [
+            tk_to_qiskit(
+                tkc, reverse_index=reverse_index, replace_implicit_swaps=replace_implicit_swaps
+            )
+            for tkc in batch
+        ]
+
 
             seed = cast(Optional[int], kwargs.get("seed"))
             job = self._backend.run(

--- a/modules/pytket-qulacs/docs/changelog.rst
+++ b/modules/pytket-qulacs/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+0.22.0 (unreleased)
+-------------------
+
+* Improve state retrieval speed.
+
 0.21.0 (July 2022)
 ------------------
 

--- a/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
+++ b/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
@@ -185,10 +185,12 @@ class QulacsBackend(Backend):
         for circuit, n_shots_circ in zip(circuits, n_shots_list):
             qulacs_state = self._sim(circuit.n_qubits)
             qulacs_state.set_zero_state()
-            qulacs_circ = tk_to_qulacs(circuit)
+            qulacs_circ = tk_to_qulacs(
+                circuit, reverse_index=True, replace_implicit_swaps=True
+            )
             qulacs_circ.update_quantum_state(qulacs_state)
             state = qulacs_state.get_vector()
-            qubits = sorted(circuit.qubits, reverse=True)
+            qubits = sorted(circuit.qubits, reverse=False)
             shots = None
             bits = None
             if n_shots_circ is not None:
@@ -215,8 +217,6 @@ class QulacsBackend(Backend):
                     "Global phase is dependent on a symbolic parameter, so cannot "
                     "adjust for phase"
                 )
-            implicit_perm = circuit.implicit_qubit_permutation()
-            qubits = [implicit_perm[qb] for qb in qubits]
             handle = ResultHandle(str(uuid4()))
             self._cache[handle] = {
                 "result": BackendResult(


### PR DESCRIPTION
``QulacsBackend``, ``AerStateBackend`` and ``AerUnitaryBackend`` now take care of implicit qubit permutation and wire endianness before running circuits. The result retrieval speed is now instant given default permutation and endianness.