### PR TITLE
Fix feedforward assignment

### DIFF
--- a/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibm.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/backends/ibm.py
@@ -259,7 +259,7 @@ class IBMQBackend(Backend):
             k: v for k, v in characterisation.items() if k in characterisation_keys
         }
         supports_mid_measure = config.simulator or config.multi_meas_enabled
-        supports_fast_feedforward = supports_mid_measure
+        supports_fast_feedforward = False
         # simulator i.e. "ibmq_qasm_simulator" does not have `supported_instructions`
         # attribute
         gate_set = _tk_gate_set(backend)


### PR DESCRIPTION
This PR fixes the wrong conditional assignment of `supports_fast_feedforward` on `supports_mid_measure`. Current IBM devices don't support it (yet) and there isn't available info in the simulator. Defaulting to `False` until further notice.