### PR TITLE
Op typefix

### DIFF
--- a/modules/pytket-qiskit/docs/intro.txt
+++ b/modules/pytket-qiskit/docs/intro.txt
@@ -20,10 +20,14 @@ Windows. To install, run:
 
     pip install pytket-qiskit
 
+
+Backends Available Through pytket-qiskit
+========================================
+
 The ``pytket-qiskit`` extension has several types of available ``Backend``. These are the ``IBMQBackend``
 and several types of simulator.
 
-.. list-table:: **Backends available through pytket-qiskit**
+.. list-table:: 
    :widths: 25 25
    :header-rows: 1
 
@@ -40,7 +44,19 @@ and several types of simulator.
    * - `AerUnitaryBackend <https://cqcl.github.io/pytket-extensions/api/qiskit/api.html#pytket.extensions.qiskit.AerUnitaryBackend>`_ 
      - Unitary simulator
 
-* [1] By default ``AerBackend`` is noiseless by default and has no architecture. However it can accept a user defined ``NoiseModel`` and ``Architecture``.
+* [1] ``AerBackend`` is noiseless by default and has no architecture. However it can accept a user defined ``NoiseModel`` and ``Architecture``.
+
+::
+
+    from pytket.extensions.qiskit import IBMQBackend
+    
+    backend = IBMQBackend('ibmq_guadalupe')
+
+Access and Credentials
+======================
+
+Default Compilation
+===================
 
 Every ``Backend`` in pytket has its own ``default_compilation_pass`` method. This method applies a sequence of optimisations to a circuit depending on the value of an ``optimisation_level`` parameter. This default compilation will ensure that the circuit meets all the constraints required to run on the Backend. The passes applied by different levels of optimisation are specified in the table below.
 
@@ -74,12 +90,31 @@ Every ``Backend`` in pytket has its own ``default_compilation_pass`` method. Thi
      - `RemoveRedundancies <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.RemoveRedundancies>`_
    * - 
      -
-     - `SimplifyInitial <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.SimplifyInitial>`_
+     - `SimplifyInitial <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.SimplifyInitial>`_ [5].
      
 * [1] If no value is specified then ``optimisation_level`` defaults to a value of 1.
 * [2] Here ``CXMappingPass`` maps program qubits to the architecture using a `NoiseAwarePlacement <https://cqcl.github.io/tket/pytket/api/placement.html#pytket.placement.NoiseAwarePlacement>`_
-* [3] self.rebase_pass is a rebase to the IBM native gate set (e.g. {X, SX, Rz, CX}).
+* [3] self.rebase_pass is a rebase to the gateset supported by the backend, For IBM quantum devices that is {X, SX, Rz, CX}.
 * [4] The ``default_compilation_pass`` for ``AerBackend`` is the same as above except it doesn't use ``SimplifyInitial``.
+* [5] ``SimplifyInitial`` has arguments ``allow_classical=False`` and ``create_all_qubits=True``.
+
+Backend Predicates
+==================
+
+Circuits must satisfy certain conditions before they can be processed on a device or simulator. In pytket these conditions are called predicates.
+
+All pytket-qiskit backends have the following two predicates.
+
+* `GateSetPredicate <https://cqcl.github.io/tket/pytket/api/predicates.html#pytket.predicates.GateSetPredicate>`_ - The circuit must contain only operations supported by the ``Backend``. To view supported Ops run ``BACKENDNAME.backend_info.gate_set``.
+* `NoSymbolsPredicate <https://cqcl.github.io/tket/pytket/api/predicates.html#pytket.predicates.NoSymbolsPredicate>`_ - Parameterised gates must have numerical values when the circuit is executed.
+
+The ``IBMQBackend`` and ``IBMQEmulatorBackend`` may also have the following predicates depending on the capabilities of the specified device.
+
+* `NoClassicalControlPredicate <https://cqcl.github.io/tket/pytket/api/predicates.html#pytket.predicates.NoClassicalControlPredicate>`_
+* `NoMidMeasurePredicate <https://cqcl.github.io/tket/pytket/api/predicates.html#pytket.predicates.NoMidMeasurePredicatePredicate>`_
+* `NoFastFeedforwardPredicate <https://cqcl.github.io/tket/pytket/api/predicates.html#pytket.predicates.NoFastFeedforwardPredicate>`_
+
+
 
 .. toctree::
     api.rst

--- a/modules/pytket-qiskit/docs/intro.txt
+++ b/modules/pytket-qiskit/docs/intro.txt
@@ -16,7 +16,70 @@ representations.
 ``pytket-qiskit`` is available for Python 3.8, 3.9 and 3.10, on Linux, MacOS and
 Windows. To install, run:
 
-``pip install pytket-qiskit``
+::
+
+    pip install pytket-qiskit
+
+The ``pytket-qiskit`` extension has several types of available ``Backend``. These are the ``IBMQBackend``
+and several types of simulator.
+
+.. list-table:: **Backends available through pytket-qiskit**
+   :widths: 25 25
+   :header-rows: 1
+
+   * - Backend
+     - Type
+   * - `IBMQBackend <https://cqcl.github.io/pytket-extensions/api/qiskit/api.html#pytket.extensions.qiskit.IBMQBackend>`_
+     - Interface to an IBM quantum computer.
+   * - `IBMQEmulatorBackend <https://cqcl.github.io/pytket-extensions/api/qiskit/api.html#pytket.extensions.qiskit.IBMQEmulatorBackend>`_
+     - Emulator for a chosen ``IBMBackend`` (Device specific).
+   * - `AerBackend <https://cqcl.github.io/pytket-extensions/api/qiskit/api.html#pytket.extensions.qiskit.AerBackend>`_
+     - A noiseless, shots-based simulator for quantum circuits [1]
+   * - `AerStateBackend <https://cqcl.github.io/pytket-extensions/api/qiskit/api.html#pytket.extensions.qiskit.AerStateBackend>`_
+     - Statevector simulator.
+   * - `AerUnitaryBackend <https://cqcl.github.io/pytket-extensions/api/qiskit/api.html#pytket.extensions.qiskit.AerUnitaryBackend>`_ 
+     - Unitary simulator
+
+* [1] By default ``AerBackend`` is noiseless by default and has no architecture. However it can accept a user defined ``NoiseModel`` and ``Architecture``.
+
+Every ``Backend`` in pytket has its own ``default_compilation_pass`` method. This method applies a sequence of optimisations to a circuit depending on the value of an ``optimisation_level`` parameter. This default compilation will ensure that the circuit meets all the constraints required to run on the Backend. The passes applied by different levels of optimisation are specified in the table below.
+
+.. list-table:: **Default compilation pass for the IBMQBackend and IBMQEmulatorBackend**
+   :widths: 25 25 25
+   :header-rows: 1
+
+   * - optimisation_level = 0
+     - optimisation_level = 1 [1]
+     - optimisation_level = 2
+   * - `DecomposeBoxes <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.DecomposeBoxes>`_
+     - `DecomposeBoxes <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.DecomposeBoxes>`_
+     - `DecomposeBoxes <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.DecomposeBoxes>`_
+   * - `CXMappingPass <https://cqcl.github.io/tket/pytket/api passes.html#pytket.passes.CXMappingPass>`_ [2]
+     - `SynthesiseTket <https://cqcl.github.io/tket/pytket/api passes.html#pytket.passes.SynthesiseTket>`_
+     - `FullPeepholeOptimise <https://cqcl.github.io/tket/pytket/api passes.html#pytket.passes.FullPeepholeOptimise>`_
+   * - `NoiseAwarePlacement <https://cqcl.github.io/tket/pytket/api/placement.html#pytket.placement.NoiseAwarePlacement>`_
+     - `CXMappingPass <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.CXMappingPass>`_ [2]
+     - `CXMappingPass <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.CXMappingPass>`_ [2]
+   * - `NaivePlacementPass <https://cqcl.github.io/tket/pytket/api/placement.html#pytket.passes.NaivePlacementPass>`_
+     - `NaivePlacementPass <https://cqcl.github.io/tket/pytket/api/placement.html#pytket.passes.NaivePlacementPass>`_
+     - `NaivePlacementPass <https://cqcl.github.io/tket/pytket/api/placement.html#pytket.passes.NaivePlacementPass>`_
+   * - self.rebase_pass [3]
+     - `SynthesiseTket <https://cqcl.github.io/tket/pytket/api passes.html#pytket.passes.SynthesiseTket>`_
+     - `CliffordSimp(allow_swaps=False) <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.CliffordSimp>`_
+   * - `RemoveRedundancies <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.RemoveRedundancies>`_
+     - `SimplifyInitial <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.SimplifyInitial>`_
+     - `SynthesiseTket <https://cqcl.github.io/tket/pytket/api passes.html#pytket.passes.SynthesiseTket>`_
+   * -
+     - self.rebase_pass [3]
+     - `RemoveRedundancies <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.RemoveRedundancies>`_
+   * - 
+     -
+     - `SimplifyInitial <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.SimplifyInitial>`_
+     
+* [1] If no value is specified then ``optimisation_level`` defaults to a value of 1.
+* [2] Here ``CXMappingPass`` maps program qubits to the architecture using a `NoiseAwarePlacement <https://cqcl.github.io/tket/pytket/api/placement.html#pytket.placement.NoiseAwarePlacement>`_
+* [3] self.rebase_pass is a rebase to the IBM native gate set (e.g. {X, SX, Rz, CX}).
+* [4] The ``default_compilation_pass`` for ``AerBackend`` is the same as above except it doesn't use ``SimplifyInitial``.
 
 .. toctree::
     api.rst

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
@@ -110,6 +110,8 @@ _qiskit_gates_2q = {
     # Exact equivalents (same signature except for factor of pi in each parameter):
     qiskit_gates.CHGate: OpType.CH,
     qiskit_gates.CPhaseGate: OpType.CU1,
+    qiskit_gates.CRXGate: OpType.CRx
+    qiskit_gates.CRYGate: OpType.CRy,
     qiskit_gates.CRZGate: OpType.CRz,
     qiskit_gates.CUGate: OpType.CU3,
     qiskit_gates.CU1Gate: OpType.CU1,
@@ -135,8 +137,6 @@ _qiskit_gates_other = {
     qiskit_gates.MCXGrayCode: OpType.CnX,
     qiskit_gates.MCXRecursive: OpType.CnX,
     qiskit_gates.MCXVChain: OpType.CnX,
-    # Note: should be OpType.CRy, but not currently available
-    qiskit_gates.CRYGate: OpType.CnRy,
     # Special types:
     Barrier: OpType.Barrier,
     Instruction: OpType.CircBox,


### PR DESCRIPTION
Using `tk_to_qiskit` fails for CRy and CRx gates. I've added these so hopefully the conversion will work for these OpTypes.

I note that there is the following comment in this file

```
# One way mapping: CRY is a special case of CnRy, but not vice versa.
# Constructing a qiskit CnRy gate is not just a single step,
# so treat as a special case.
del _known_qiskit_gate_rev[OpType.CnRy]
```
I'm pretty sure this is not relevant but just wanted to make sure there wasn't a good reason why OpType.CRy and OpType.CRx were left out
