### PR TITLE
add CRx and CRy

### DIFF
--- a/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
@@ -110,6 +110,8 @@ _qiskit_gates_2q = {
     # Exact equivalents (same signature except for factor of pi in each parameter):
     qiskit_gates.CHGate: OpType.CH,
     qiskit_gates.CPhaseGate: OpType.CU1,
+    qiskit_gates.CRXGate: OpType.CRx,
+    qiskit_gates.CRYGate: OpType.CRy,
     qiskit_gates.CRZGate: OpType.CRz,
     qiskit_gates.CUGate: OpType.CU3,
     qiskit_gates.CU1Gate: OpType.CU1,
@@ -135,8 +137,6 @@ _qiskit_gates_other = {
     qiskit_gates.MCXGrayCode: OpType.CnX,
     qiskit_gates.MCXRecursive: OpType.CnX,
     qiskit_gates.MCXVChain: OpType.CnX,
-    # Note: should be OpType.CRy, but not currently available
-    qiskit_gates.CRYGate: OpType.CnRy,
     # Special types:
     Barrier: OpType.Barrier,
     Instruction: OpType.CircBox,

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
@@ -152,11 +152,6 @@ _known_qiskit_gate = {**_qiskit_gates_1q, **_qiskit_gates_2q, **_qiskit_gates_ot
 # In such cases this reversal will select one or the other.
 _known_qiskit_gate_rev = {v: k for k, v in _known_qiskit_gate.items()}
 
-# One way mapping: CRY is a special case of CnRy, but not vice versa.
-# Constructing a qiskit CnRy gate is not just a single step,
-# so treat as a special case.
-del _known_qiskit_gate_rev[OpType.CnRy]
-
 # Ensure U3 maps to UGate. (U3Gate deprecated in Qiskit but equivalent.)
 _known_qiskit_gate_rev[OpType.U3] = qiskit_gates.UGate
 

--- a/modules/pytket-qiskit/tests/qiskit_convert_test.py
+++ b/modules/pytket-qiskit/tests/qiskit_convert_test.py
@@ -684,7 +684,7 @@ def test_convert_multi_c_reg() -> None:
     assert circ.get_commands()[0].args == [m0, q1]
 
 
-# test that tk_to_qiskit works after adding OpType.CRx and OpType.CRy (TKET-2386)
+# test that tk_to_qiskit works after adding OpType.CRx and OpType.CRy
 def test_crx_and_cry() -> None:
     tk_circ = Circuit(2)
     tk_circ.CRx(0.5, 0, 1)

--- a/modules/pytket-qiskit/tests/qiskit_convert_test.py
+++ b/modules/pytket-qiskit/tests/qiskit_convert_test.py
@@ -682,3 +682,13 @@ def test_convert_multi_c_reg() -> None:
     qcirc = tk_to_qiskit(c)
     circ = qiskit_to_tk(qcirc)
     assert circ.get_commands()[0].args == [m0, q1]
+
+
+# test that qiskit_to_tk works after adding OpType.CRx and OpType CRy (TKET-2386)
+def test_crx_and_cry() -> None:
+    tk_circ = Circuit(2)
+    tk_circ.CRx(0.5, 0, 1)
+    tk_circ.CRy(0.2, 1, 0)
+    qiskit_circ = tk_to_qiskit(tk_circ)
+    ops_dict = qiskit_circ.count_ops
+    assert ops_dict["crx"] == 1 and ops_dict["cry"] == 1

--- a/modules/pytket-qiskit/tests/qiskit_convert_test.py
+++ b/modules/pytket-qiskit/tests/qiskit_convert_test.py
@@ -690,5 +690,5 @@ def test_crx_and_cry() -> None:
     tk_circ.CRx(0.5, 0, 1)
     tk_circ.CRy(0.2, 1, 0)
     qiskit_circ = tk_to_qiskit(tk_circ)
-    ops_dict = qiskit_circ.count_ops
+    ops_dict = qiskit_circ.count_ops()
     assert ops_dict["crx"] == 1 and ops_dict["cry"] == 1

--- a/modules/pytket-qiskit/tests/qiskit_convert_test.py
+++ b/modules/pytket-qiskit/tests/qiskit_convert_test.py
@@ -684,7 +684,7 @@ def test_convert_multi_c_reg() -> None:
     assert circ.get_commands()[0].args == [m0, q1]
 
 
-# test that qiskit_to_tk works after adding OpType.CRx and OpType CRy (TKET-2386)
+# test that tk_to_qiskit works after adding OpType.CRx and OpType.CRy (TKET-2386)
 def test_crx_and_cry() -> None:
     tk_circ = Circuit(2)
     tk_circ.CRx(0.5, 0, 1)


### PR DESCRIPTION
As pointed out in the #tket-support channel `tk_to_qiskit` was failing for CRx and CRy operations. I have now added these to qiskit_convert.py to fix this.

I don't think there is any reason why these were left out but correct me if I'm wrong.

I have moved CRy fron `_qiskit_gates_other` to `_qiskit_gates_2q` is this the right place for it?

There is also a comment here about the CnRy which is probably irrelevant to this.

```
One way mapping: CRY is a special case of CnRy, but not vice versa.
Constructing a qiskit CnRy gate is not just a single step,
so treat as a special case.
del _known_qiskit_gate_rev[OpType.CnRy]
```

