### PR TITLE
Support ECRGate in `pytket-qiskit` circuit conversion

### DIFF
--- a/modules/pytket-qiskit/docs/changelog.rst
+++ b/modules/pytket-qiskit/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 -------------------
 
 * Add post-routing ``KAKDecomposition`` to default pass with ``optimisation_level`` = 2.
+* Add support for ``ECRGate`` in ``tk_to_qiskit`` conversion.
 
 0.28.0 (August 2022)
 --------------------

--- a/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
+++ b/modules/pytket-qiskit/pytket/extensions/qiskit/qiskit_convert.py
@@ -119,6 +119,7 @@ _qiskit_gates_2q = {
     qiskit_gates.CXGate: OpType.CX,
     qiskit_gates.CYGate: OpType.CY,
     qiskit_gates.CZGate: OpType.CZ,
+    qiskit_gates.ECRGate: OpType.ECR,
     qiskit_gates.iSwapGate: OpType.ISWAPMax,
     qiskit_gates.RXXGate: OpType.XXPhase,
     qiskit_gates.RYYGate: OpType.YYPhase,

--- a/modules/pytket-qiskit/tests/qiskit_convert_test.py
+++ b/modules/pytket-qiskit/tests/qiskit_convert_test.py
@@ -95,6 +95,7 @@ def get_test_circuit(measure: bool, reset: bool = True) -> QuantumCircuit:
     qc.cu(pi / 4, pi / 5, pi / 6, 0, qr[3], qr[0])
     qc.cy(qr[0], qr[1])
     qc.cz(qr[1], qr[2])
+    qc.ecr(qr[0], qr[1])
     qc.i(qr[2])
     qc.iswap(qr[3], qr[0])
     qc.mct([qr[0], qr[1], qr[2]], qr[3])


### PR DESCRIPTION
At the moment, attempting to convert a tket circuit containing `ecr` gates (one of the basis gates in OQC's quantum computers) to a qiskit circuit (via the `tk_to_qiskit` method) raises the following error
```console
NotImplementedError: Cannot convert tket Op to Qiskit gate: ECR
```
This simple PR fixes the underlying issue by adding the `ECRGate` to the `_qiskit_gates_2q` list in the qiskit converter.
As a result, circuits compiled to the OQC device using tket can be translated to Qiskit without errors.

