### PR TITLE
Add missing backend info for Qulacs / Cirq / PySimplex / Stim backends

### DIFF
--- a/modules/pytket-cirq/tests/test_cirq_backend.py
+++ b/modules/pytket-cirq/tests/test_cirq_backend.py
@@ -15,6 +15,7 @@
 from collections import Counter
 from typing import List
 import math
+
 from hypothesis import given, strategies
 import numpy as np
 import pytest
@@ -31,6 +32,7 @@ from pytket.extensions.cirq.backends.cirq import (
 )
 from pytket.circuit import Circuit, Qubit, Bit  # type: ignore
 from pytket.backends import StatusEnum
+from pytket.backends.backendinfo import BackendInfo
 from pytket.predicates import GateSetPredicate  # type: ignore
 from cirq.contrib.noise_models import DepolarizingNoiseModel  # type: ignore
 
@@ -367,9 +369,9 @@ def test_invalid_n_shots_in_sim_backends(cirq_backend: _CirqSimBackend) -> None:
         CirqCliffordSimBackend(),
     ],
 )
-def test_backend_info_and_characterisation_are_none(
+def test_backend_info_is_set_and_characterisation_is_none(
     cirq_backend: _CirqBaseBackend,
 ) -> None:
     b = cirq_backend
-    assert b.backend_info == None
-    assert b.characterisation == None
+    assert isinstance(b.backend_info, BackendInfo)
+    assert b.characterisation is None

--- a/modules/pytket-pysimplex/pytket/extensions/pysimplex/backends/simplex_backend.py
+++ b/modules/pytket-pysimplex/pytket/extensions/pysimplex/backends/simplex_backend.py
@@ -16,6 +16,7 @@ from typing import cast, List, Optional, Sequence, Union
 from uuid import uuid4
 import numpy as np
 from pysimplex import Simplex  # type: ignore
+from pytket.architecture import Architecture  # type: ignore
 from pytket.backends import (
     Backend,
     CircuitNotRunError,
@@ -23,9 +24,11 @@ from pytket.backends import (
     ResultHandle,
     StatusEnum,
 )
+from pytket.backends.backendinfo import BackendInfo
 from pytket.backends.backendresult import BackendResult
 from pytket.backends.resulthandle import _ResultIdTuple
 from pytket.circuit import Circuit, OpType  # type: ignore
+from pytket.extensions.pysimplex._metadata import __extension_version__
 from pytket.passes import (  # type: ignore
     BasePass,
     DecomposeBoxes,
@@ -144,6 +147,20 @@ class SimplexBackend(Backend):
 
     _supports_shots = True
     _supports_counts = True
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._backend_info = BackendInfo(
+            type(self).__name__,
+            None,
+            __extension_version__,
+            Architecture([]),
+            _gateset,
+        )
+
+    @property
+    def backend_info(self) -> Optional[BackendInfo]:
+        return self._backend_info
 
     @property
     def required_predicates(self) -> List[Predicate]:

--- a/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
+++ b/modules/pytket-qulacs/pytket/extensions/qulacs/backends/qulacs_backend.py
@@ -123,7 +123,7 @@ class QulacsBackend(Backend):
 
     @property
     def backend_info(self) -> Optional["BackendInfo"]:
-        return None
+        return self._backend_info
 
     @property
     def required_predicates(self) -> List[Predicate]:

--- a/modules/pytket-stim/pytket/extensions/stim/backends/stim_backend.py
+++ b/modules/pytket-stim/pytket/extensions/stim/backends/stim_backend.py
@@ -14,6 +14,7 @@
 
 from typing import cast, List, Optional, Sequence, Union
 from uuid import uuid4
+from pytket.architecture import Architecture  # type: ignore
 from pytket.backends import (
     Backend,
     CircuitNotRunError,
@@ -21,9 +22,11 @@ from pytket.backends import (
     ResultHandle,
     StatusEnum,
 )
+from pytket.backends.backendinfo import BackendInfo
 from pytket.backends.backendresult import BackendResult
 from pytket.backends.resulthandle import _ResultIdTuple
 from pytket.circuit import Circuit, OpType  # type: ignore
+from pytket.extensions.stim._metadata import __extension_version__
 from pytket.passes import (  # type: ignore
     BasePass,
     DecomposeBoxes,
@@ -121,6 +124,20 @@ class StimBackend(Backend):
 
     _supports_shots = True
     _supports_counts = True
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._backend_info = BackendInfo(
+            type(self).__name__,
+            None,
+            __extension_version__,
+            Architecture([]),
+            set(_gate.keys()),
+        )
+
+    @property
+    def backend_info(self) -> Optional[BackendInfo]:
+        return self._backend_info
 
     @property
     def required_predicates(self) -> List[Predicate]:


### PR DESCRIPTION
QulacsBackend and the Cirq backends previously had the `backend_info` property set as `None`, and StimBackend and SimplexBackend did not have the `backend_info` property set at all.

This PR makes the `.backend_info` property of these backends return `BackendInfo` instances that have the name, extension version and gatesets set. (The other properties aren't very useful for locally-run simulators, as far as I can tell, so I've not set them.)