### PR TITLE
Update to qsharp 0.26; enable Windows/3.10 support and MacOS/3.10 tests

### DIFF
--- a/.github/workflows/build-test
+++ b/.github/workflows/build-test
@@ -35,10 +35,6 @@ python -m pip install --upgrade pip wheel build
 
 function unsupported() {
     case "$1" in
-        pytket-qsharp)
-            # Cannot install qsharp on Windows with 3.10.
-            [[ "${PLAT}" == "Windows" && ${PYVER} == "3.10" ]] && return
-            ;;
         pytket-qulacs)
             # Cannot install qulacs on MacOS or Windows with 3.10.
             [[ "${PLAT}" != "Linux" && "${PYVER}" == "3.10" ]] && return
@@ -51,17 +47,6 @@ function unsupported() {
 
 function skip_tests() {
     case "$1" in
-        pytket-qsharp)
-            case "${PLAT}" in
-                Darwin)
-                    # Test timeout issues
-                    [[ ${PYVER} == "3.10" ]] && return
-                    ;;
-                *)
-                    false
-                    ;;
-            esac
-            ;;
         *)
             false
             ;;

--- a/modules/pytket-qsharp/README.md
+++ b/modules/pytket-qsharp/README.md
@@ -16,7 +16,7 @@ as well as local simulators and resource estimators from the Microsoft QDK.
 ## Getting started
 
 `pytket-qsharp` is available for Python 3.8, 3.9 and 3.10, on Linux, MacOS and
-Windows (except for Windows with 3.10). To install, run:
+Windows. To install, run:
 
 ```pip install pytket-qsharp```
 

--- a/modules/pytket-qsharp/_metadata.py
+++ b/modules/pytket-qsharp/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.28.0"
+__extension_version__ = "0.29.0"
 __extension_name__ = "pytket-qsharp"

--- a/modules/pytket-qsharp/docs/changelog.rst
+++ b/modules/pytket-qsharp/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 
 * Updated pytket version requirement to 1.6.
 * Updated qsharp version requirement to 0.26.
+* Support Python 3.10 on Windows.
 
 0.28.0 (August 2022)
 --------------------

--- a/modules/pytket-qsharp/docs/changelog.rst
+++ b/modules/pytket-qsharp/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 ~~~~~~~~~
 
+0.29.0 (unreleased)
+-------------------
+
+* Updated pytket version requirement to 1.6.
+* Updated qsharp version requirement to 0.26.
+
 0.28.0 (August 2022)
 --------------------
 

--- a/modules/pytket-qsharp/docs/intro.txt
+++ b/modules/pytket-qsharp/docs/intro.txt
@@ -12,7 +12,7 @@ language and associated toolkit for quantum programming.
 executed on simulators and resource estimators from the Microsoft QDK.
 
 ``pytket-qsharp`` is available for Python 3.8, 3.9 and 3.10, on Linux, MacOS and
-Windows (except for Windows with 3.10). To install, run:
+Windows. To install, run:
 
 ::
    

--- a/modules/pytket-qsharp/pytket/extensions/qsharp/qsharp_convert.py
+++ b/modules/pytket-qsharp/pytket/extensions/qsharp/qsharp_convert.py
@@ -41,7 +41,7 @@ def cmd_body(op: Op, qbs: List[int]) -> str:
     elif optype == OpType.H:
         return "H(q[{}])".format(*qbs)
     elif optype == OpType.noop:
-        pass
+        return ""
     elif optype == OpType.Rx:
         return "Rx({}, q[{}])".format(pi * op.params[0], qbs[0])
     elif optype == OpType.Ry:

--- a/modules/pytket-qsharp/setup.py
+++ b/modules/pytket-qsharp/setup.py
@@ -39,9 +39,9 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket ~= 1.5",
-        "qsharp ~= 0.25.218240",
-        "qsharp-core ~= 0.25.218240",
+        "pytket ~= 1.6",
+        "qsharp ~= 0.26.232864",
+        "qsharp-core ~= 0.26.232864",
     ],
     classifiers=[
         "Environment :: Console",


### PR DESCRIPTION
Closes #268 .